### PR TITLE
fix(extension): prevent duplicate status-bar item on reactivation

### DIFF
--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -20,6 +20,14 @@ const { readMeminfo, sh, checkServiceStatus } = require('./utils');
 // Single source of truth — referenced by setInterval and the tooltip text.
 const POLL_INTERVAL_MS = 2000;
 
+// ── Activation/runtime singletons ───────────────────────────────────────────
+// Defensive guard: activate() should run once per extension host process.
+// If VS Code triggers activation again in the same process, avoid creating a
+// second status-bar item and timer.
+let _activated = false;
+let _statusItem = null;
+let _statusTimer = null;
+
 // ── Full status bar state cache ──────────────────────────────────────────────
 // Key encodes all visible output (svcStatus + rounded pct% + availMB).
 // When stable, skips ALL four StatusBarItem property assignments and their
@@ -40,6 +48,17 @@ let _updating = false;
 //   cacheHits:   times stateKey matched → all 4 StatusBarItem IPC calls skipped
 //   cacheMisses: times stateKey differed → full IPC round-trip fired
 const _stats = { dropped: 0, cacheHits: 0, cacheMisses: 0 };
+
+function disposeRuntimeUi() {
+    if (_statusTimer) {
+        clearInterval(_statusTimer);
+        _statusTimer = null;
+    }
+    if (_statusItem) {
+        try { _statusItem.dispose(); } catch {}
+        _statusItem = null;
+    }
+}
 
 async function update(item) {
     if (_updating) { _stats.dropped++; return; }
@@ -122,6 +141,11 @@ async function update(item) {
 // ── Extension entry points ────────────────────────────────────────────────────
 
 async function activate(context) {
+    if (_activated) {
+        return;
+    }
+    _activated = true;
+
     // ── 1. Install / upgrade the daemon ──────────────────────────────────────
     try {
         const outcome = await installer.installOrUpgrade(context);
@@ -183,6 +207,8 @@ async function activate(context) {
     );
 
     // ── 5. Status bar ─────────────────────────────────────────────────────────
+    disposeRuntimeUi();
+
     const item = vscode.window.createStatusBarItem(
         'mem-watchdog-status',
         vscode.StatusBarAlignment.Left,
@@ -191,16 +217,20 @@ async function activate(context) {
     item.name    = 'Mem Watchdog';
     item.command = 'memWatchdog.showDashboard'; // clicking opens dashboard
     item.show();
+    _statusItem = item;
 
     update(item);
     const timer = setInterval(() => update(item), POLL_INTERVAL_MS);
+    _statusTimer = timer;
 
     context.subscriptions.push(item);
     context.subscriptions.push({ dispose: () => clearInterval(timer) });
+    context.subscriptions.push({ dispose: () => { disposeRuntimeUi(); _activated = false; } });
 }
 
 function deactivate() {
-    // Subscriptions are disposed automatically via context.subscriptions.
+    disposeRuntimeUi();
+    _activated = false;
 }
 
 module.exports = { activate, deactivate };

--- a/vscode-extension/test/unit/extension.activate.test.js
+++ b/vscode-extension/test/unit/extension.activate.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const { setup: vsSetup, mockWindow, mockWorkspace, mockVscode } = require('../helpers/mockVscode');
+vsSetup();
+
+let createdItems = [];
+let disposedItems = 0;
+
+mockWindow.createStatusBarItem = function () {
+    const item = {
+        text: '',
+        color: undefined,
+        backgroundColor: undefined,
+        tooltip: undefined,
+        command: undefined,
+        name: undefined,
+        show() {},
+        dispose() { disposedItems++; },
+    };
+    createdItems.push(item);
+    return item;
+};
+
+mockWorkspace.onDidChangeConfiguration = () => ({ dispose() {} });
+mockVscode.commands.registerCommand = () => ({ dispose() {} });
+
+const installerPath = path.resolve(__dirname, '../../installer.js');
+const configWriterPath = path.resolve(__dirname, '../../configWriter.js');
+const commandsPath = path.resolve(__dirname, '../../commands.js');
+const utilsPath = path.resolve(__dirname, '../../utils.js');
+
+require.cache[installerPath] = {
+    id: installerPath,
+    filename: installerPath,
+    loaded: true,
+    paths: [],
+    exports: {
+        installOrUpgrade: async () => 'current',
+    },
+};
+
+require.cache[configWriterPath] = {
+    id: configWriterPath,
+    filename: configWriterPath,
+    loaded: true,
+    paths: [],
+    exports: {
+        writeConfig: () => [],
+    },
+};
+
+require.cache[commandsPath] = {
+    id: commandsPath,
+    filename: commandsPath,
+    loaded: true,
+    paths: [],
+    exports: {
+        showDashboard() {},
+        preflightCheck() {},
+        killChrome() {},
+        restartService() {},
+        dispose() {},
+    },
+};
+
+require.cache[utilsPath] = {
+    id: utilsPath,
+    filename: utilsPath,
+    loaded: true,
+    paths: [],
+    exports: {
+        readMeminfo: () => ({ totalKB: 6440000, availableKB: 4000000, pct: 62 }),
+        sh: async () => ({ ok: true, stdout: '', stderr: '' }),
+        checkServiceStatus: async () => 'active',
+    },
+};
+
+const ext = require('../../extension');
+
+function makeContext() {
+    return { subscriptions: [] };
+}
+
+function disposeContext(context) {
+    for (const sub of context.subscriptions) {
+        if (sub && typeof sub.dispose === 'function') {
+            sub.dispose();
+        }
+    }
+}
+
+beforeEach(() => {
+    createdItems = [];
+    disposedItems = 0;
+    ext.deactivate();
+});
+
+test('activate() is idempotent in-process: second call does not create a second status item', async () => {
+    const contextA = makeContext();
+    const contextB = makeContext();
+
+    await ext.activate(contextA);
+    await ext.activate(contextB);
+
+    assert.equal(createdItems.length, 1,
+        `expected exactly one status bar item across repeated activate() calls, got ${createdItems.length}`);
+
+    ext.deactivate();
+    disposeContext(contextA);
+    disposeContext(contextB);
+
+    assert.ok(disposedItems >= 1, 'expected created status bar item to be disposed on deactivate/disposal');
+});


### PR DESCRIPTION
## Summary
Fixes duplicate Mem Watchdog status-bar UI items by making extension activation idempotent in-process.

## What changed
- Added activation singleton guards in [vscode-extension/extension.js](vscode-extension/extension.js):
  - `_activated` re-entry guard in `activate()`
  - module-level `_statusItem` and `_statusTimer`
  - `disposeRuntimeUi()` for deterministic cleanup
  - `deactivate()` now disposes runtime UI resources and resets activation state
- Added regression test [vscode-extension/test/unit/extension.activate.test.js](vscode-extension/test/unit/extension.activate.test.js)
  - Verifies repeated `activate()` calls create exactly one status-bar item
  - Verifies item disposal on deactivation/cleanup

## Validation
- ✅ `cd vscode-extension && npm test` (56/56 passing)
- ✅ `bash -n mem-watchdog.sh`
- ✅ `shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh`
- ⚠️ `bash test-watchdog.sh` currently fails pre-existing environment gate:
  - Test 4: `argv.json heap=1024 (expected 2048)`
  - Not introduced by this change (extension-only patch)

## Lifecycle
Closes #35
