### PR TITLE
fix(config): align issue governance workflow with repo taxonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_fix.md
+++ b/.github/ISSUE_TEMPLATE/bug_fix.md
@@ -1,14 +1,18 @@
 ---
 name: Bug-fix
 about: Defect, regression, or reliability failure
-title: "[Bug-fix] "
+title: ""
 labels: type: bug-fix,bug
 assignees: chf3198
 ---
 
-## Symptom
+## Problem
 
 <!-- What failed? Include observed behavior and impact. -->
+
+## Impact
+
+<!-- What reliability, release, or user-facing harm does this bug cause? -->
 
 ## Reproduction
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,18 @@
 ---
 name: Bug report
 about: Something isn't working as expected in the daemon or extension
-title: "[Bug] "
+title: ""
 labels: bug,type: bug-fix
 assignees: chf3198
 ---
+
+## Problem
+
+<!-- Describe what failed in plain language. -->
+
+## Impact
+
+<!-- Describe the user-facing or reliability impact. -->
 
 ## Environment
 
@@ -28,6 +36,12 @@ assignees: chf3198
 ## What you expected
 
 <!-- Describe what you expected to happen. -->
+
+## Acceptance criteria
+
+- [ ] Repro and environment details are complete
+- [ ] Expected behavior is stated clearly
+- [ ] Supporting logs or memory evidence are attached below
 
 ## Journal output
 

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,14 +1,18 @@
 ---
 name: Epic
 about: Multi-issue initiative tracked across milestones
-title: "[Epic] "
+title: ""
 labels: type: epic
 assignees: chf3198
 ---
 
-## Outcome
+## Objective
 
 <!-- What business/technical outcome must this epic deliver? -->
+
+## Impact
+
+<!-- Why does this epic matter now? What risk, user pain, or delivery goal does it address? -->
 
 ## Scope
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,21 +1,31 @@
 ---
 name: Feature request
 about: Suggest an improvement or new capability
-title: "[Feature] "
+title: ""
 labels: enhancement,type: task
 assignees: chf3198
 ---
 
-## Problem statement
+## Problem
 
 <!-- What problem would this feature solve? Be specific: what crash, failure mode,
 or workflow gap are you experiencing? -->
+
+## Impact
+
+<!-- Why does this need to happen now, and what improves if it lands? -->
 
 ## Proposed solution
 
 <!-- Describe the change you'd like. If it touches mem-watchdog.sh, note whether
 it keeps to bash + coreutils with no external deps. If it touches the extension,
 note whether it affects the statusbar poll path (hot path — every 2 s). -->
+
+## Acceptance criteria
+
+- [ ] Desired outcome is clear and measurable
+- [ ] Constraints and affected surfaces are identified
+- [ ] Follow-up validation approach is stated
 
 ## Alternatives considered
 

--- a/.github/ISSUE_TEMPLATE/research.md
+++ b/.github/ISSUE_TEMPLATE/research.md
@@ -1,25 +1,29 @@
 ---
 name: Research
 about: Investigation, benchmarking, or architecture validation
-title: "[Research] "
+title: ""
 labels: type: research,research
 assignees: chf3198
 ---
 
-## Question
+## Objective
 
 <!-- What needs to be proven, measured, or ruled out? -->
+
+## Impact
+
+<!-- Why is answering this question important for roadmap, risk, or implementation decisions? -->
 
 ## Method
 
 <!-- How will this be evaluated? Include tools/commands/data sources. -->
 
-## Deliverables
+## Acceptance criteria
 
 - [ ] Findings document in `docs/technical/`
 - [ ] Recommendation summary
 - [ ] Follow-up implementation issue(s) created
 
-## Exit criteria
+## Validation
 
-<!-- Define what “done research” means. -->
+<!-- Define what evidence proves the research is complete and actionable. -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,7 +1,7 @@
 ---
 name: Task
 about: Scoped implementation or documentation task
-title: "[Task] "
+title: ""
 labels: type: task
 assignees: chf3198
 ---
@@ -9,6 +9,10 @@ assignees: chf3198
 ## Problem
 
 <!-- What gap does this task close? -->
+
+## Impact
+
+<!-- What user, reliability, release, or workflow impact comes from doing this work? -->
 
 ## Proposed change
 

--- a/.github/workflows/issues-governance.yml
+++ b/.github/workflows/issues-governance.yml
@@ -48,6 +48,7 @@ jobs:
             const title = (issue.title || '').trim();
             const body = (issue.body || '').toLowerCase();
             const labels = (issue.labels || []).map(l => (l.name || '').toLowerCase());
+            const approvedDomainLabels = ['policy', 'psi', 'cgroup', 'oom', 'crostini', 'testing', 'performance', 'research'];
 
             const violations = [];
 
@@ -65,10 +66,10 @@ jobs:
             // Required labels
             const hasType = labels.some(l => l.startsWith('type:'));
             const hasPriority = labels.some(l => l.startsWith('priority:'));
-            const hasArea = labels.some(l => l.startsWith('area:'));
+            const hasDomain = labels.some(l => approvedDomainLabels.includes(l));
             if (!hasType) violations.push('Missing a type label (`type:*`).');
             if (!hasPriority) violations.push('Missing a priority label (`priority:*`).');
-            if (!hasArea) violations.push('Missing an area label (`area:*`).');
+            if (!hasDomain) violations.push('Missing an approved domain label (`policy`, `psi`, `cgroup`, `oom`, `crostini`, `testing`, `performance`, or `research`).');
 
             // Body policy
             if (!body.includes('acceptance criteria')) {
@@ -179,6 +180,7 @@ Please update the issue. This label will auto-clear when checks pass.`;
             });
 
             const disallowedTitlePrefix = /^(?:\[[^\]]+\]\s*|ticket-\d+\s*:\s*|[a-z]+-\d+\s*:\s*|(?:feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert|content|research|epic)\([^\)]+\)\s*:\s*)/i;
+            const approvedDomainLabels = ['policy', 'psi', 'cgroup', 'oom', 'crostini', 'testing', 'performance', 'research'];
             let flagged = 0;
 
             for (const issue of issues) {
@@ -191,9 +193,10 @@ Please update the issue. This label will auto-clear when checks pass.`;
               if (!title || title.length > 72 || disallowedTitlePrefix.test(title)) bad = true;
               if (!labels.some(l => l.startsWith('type:'))) bad = true;
               if (!labels.some(l => l.startsWith('priority:'))) bad = true;
-              if (!labels.some(l => l.startsWith('area:'))) bad = true;
+              if (!labels.some(l => approvedDomainLabels.includes(l))) bad = true;
               if (!body.includes('acceptance criteria')) bad = true;
               if (!(body.includes('problem') || body.includes('objective'))) bad = true;
+              if (!body.includes('impact')) bad = true;
 
               const hasNeeds = labels.includes('governance:needs-triage');
               if (bad && !hasNeeds) {

--- a/docs/workflow/learnings.md
+++ b/docs/workflow/learnings.md
@@ -20,6 +20,16 @@
 
 ---
 
+### 2026-03-24 — Issues governance workflow drifted from repo taxonomy and templates
+
+**Context**: Verifying the `v0.3.4` release surfaced repeated failures from `.github/workflows/issues-governance.yml` while the release itself was healthy.
+
+**Discovery**: The workflow had been enforcing an `area:*` label and rejecting prefixed issue titles, but this repository's documented governance model requires one taxonomy label, one priority label, and at least one domain label from the established set (`policy`, `psi`, `cgroup`, `oom`, `crostini`, `testing`, `performance`, `research`). At the same time, several shipped issue templates still defaulted to prefixed titles like `[Epic]` and `[Task]`, and some templates omitted the `Impact` / `Acceptance criteria` sections the workflow expected. The result was self-inflicted governance noise: the workflow, docs, and templates were contradicting one another.
+
+**Application**: Keep the governance workflow, issue templates, and contributor/admin docs aligned as one change set. For this repository, validate domain labels explicitly instead of `area:*`, keep issue titles plain imperative in templates, and ensure every template includes `Problem` or `Objective`, `Impact`, and `Acceptance criteria` so automation and human policy agree.
+
+---
+
 ### 2026-03-19 — Global Copilot standards require a 4-layer model (instructions + skills + hooks + CI)
 
 **Context**: Expanding automation strategy from repo-only CI checks to cross-repository adoption for current and future repositories.


### PR DESCRIPTION
## Summary
- align `.github/workflows/issues-governance.yml` with the repository's documented domain-label taxonomy
- normalize issue templates to plain imperative titles and required `Problem`/`Objective`, `Impact`, and `Acceptance criteria` sections
- record the workflow/template drift in `docs/workflow/learnings.md`

## Validation
- `bash test-watchdog.sh`
- `bash -n mem-watchdog.sh`
- `shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh`
- `cd vscode-extension && npm test`
- open-issue title audit: no remaining prefixed titles among open issues

Closes #37
