### PR TITLE
fix(config): reset stale issues governance workflow registration

### DIFF
--- a/.github/workflows/issue-governance.yml
+++ b/.github/workflows/issue-governance.yml
@@ -1,0 +1,228 @@
+name: Issues Governance
+
+on:
+  issues:
+    types: [opened, edited, reopened, labeled, unlabeled]
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  ignore_unexpected_event:
+    if: github.event_name != 'issues' && github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ignore unsupported event
+        run: echo "Skipping issues governance for unsupported event: ${GITHUB_EVENT_NAME}"
+
+  validate_issue_event:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure governance label exists
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'governance:needs-triage'
+              });
+            } catch (e) {
+              if (e.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: 'governance:needs-triage',
+                  color: 'B60205',
+                  description: 'Issue fails governance policy checks and needs triage'
+                });
+              } else {
+                throw e;
+              }
+            }
+
+      - name: Validate issue policy
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const title = (issue.title || '').trim();
+            const body = (issue.body || '').toLowerCase();
+            const labels = (issue.labels || []).map(l => (l.name || '').toLowerCase());
+            const approvedDomainLabels = ['policy', 'psi', 'cgroup', 'oom', 'crostini', 'testing', 'performance', 'research'];
+
+            const violations = [];
+
+            const disallowedTitlePrefix = /^(?:\[[^\]]+\]\s*|ticket-\d+\s*:\s*|[a-z]+-\d+\s*:\s*|(?:feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert|content|research|epic)\([^\)]+\)\s*:\s*)/i;
+            if (!title) {
+              violations.push('Title is required.');
+            } else {
+              if (title.length > 72) violations.push('Title must be 72 characters or fewer.');
+              if (disallowedTitlePrefix.test(title)) {
+                violations.push('Title must be plain imperative text (no prefixes like TICKET-123, [BUG], or type(scope):).');
+              }
+            }
+
+            const hasType = labels.some(l => l.startsWith('type:'));
+            const hasPriority = labels.some(l => l.startsWith('priority:'));
+            const hasDomain = labels.some(l => approvedDomainLabels.includes(l));
+            if (!hasType) violations.push('Missing a type label (`type:*`).');
+            if (!hasPriority) violations.push('Missing a priority label (`priority:*`).');
+            if (!hasDomain) violations.push('Missing an approved domain label (`policy`, `psi`, `cgroup`, `oom`, `crostini`, `testing`, `performance`, or `research`).');
+
+            if (!body.includes('acceptance criteria')) {
+              violations.push('Body must include an "Acceptance criteria" section.');
+            }
+            if (!(body.includes('problem') || body.includes('objective'))) {
+              violations.push('Body must include a "Problem" or "Objective" section.');
+            }
+            if (!body.includes('impact')) {
+              violations.push('Body should include an "Impact" section.');
+            }
+
+            const needsLabel = 'governance:needs-triage';
+            const hasNeedsLabel = labels.includes(needsLabel);
+
+            if (violations.length > 0) {
+              if (!hasNeedsLabel) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: [needsLabel]
+                });
+              }
+
+              const marker = '<!-- issues-governance-comment -->';
+              const bodyText = `${marker}
+❌ This issue is missing required governance fields:
+
+${violations.map(v => `- [ ] ${v}`).join('\n')}
+
+Please update the issue. This label will auto-clear when checks pass.`;
+
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100
+              });
+              const existing = comments.find(c => c.user?.type === 'Bot' && (c.body || '').includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: bodyText
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: bodyText
+                });
+              }
+
+              core.setFailed(`Issue #${issue.number} failed governance checks.`);
+            } else {
+              if (hasNeedsLabel) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  name: needsLabel
+                }).catch(() => {});
+              }
+            }
+
+  scheduled_audit:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure governance label exists
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'governance:needs-triage'
+              });
+            } catch (e) {
+              if (e.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: 'governance:needs-triage',
+                  color: 'B60205',
+                  description: 'Issue fails governance policy checks and needs triage'
+                });
+              } else {
+                throw e;
+              }
+            }
+
+      - name: Audit open issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            const disallowedTitlePrefix = /^(?:\[[^\]]+\]\s*|ticket-\d+\s*:\s*|[a-z]+-\d+\s*:\s*|(?:feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert|content|research|epic)\([^\)]+\)\s*:\s*)/i;
+            const approvedDomainLabels = ['policy', 'psi', 'cgroup', 'oom', 'crostini', 'testing', 'performance', 'research'];
+            let flagged = 0;
+
+            for (const issue of issues) {
+              if (issue.pull_request) continue;
+              const title = (issue.title || '').trim();
+              const body = (issue.body || '').toLowerCase();
+              const labels = (issue.labels || []).map(l => (l.name || '').toLowerCase());
+
+              let bad = false;
+              if (!title || title.length > 72 || disallowedTitlePrefix.test(title)) bad = true;
+              if (!labels.some(l => l.startsWith('type:'))) bad = true;
+              if (!labels.some(l => l.startsWith('priority:'))) bad = true;
+              if (!labels.some(l => approvedDomainLabels.includes(l))) bad = true;
+              if (!body.includes('acceptance criteria')) bad = true;
+              if (!(body.includes('problem') || body.includes('objective'))) bad = true;
+              if (!body.includes('impact')) bad = true;
+
+              const hasNeeds = labels.includes('governance:needs-triage');
+              if (bad && !hasNeeds) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: ['governance:needs-triage']
+                });
+                flagged += 1;
+              }
+              if (!bad && hasNeeds) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  name: 'governance:needs-triage'
+                }).catch(() => {});
+              }
+            }
+
+            core.summary
+              .addHeading('Issues Governance Audit')
+              .addRaw(`Open issues scanned: ${issues.filter(i => !i.pull_request).length}`)
+              .addBreak()
+              .addRaw(`Newly flagged: ${flagged}`)
+              .write();

--- a/docs/workflow/learnings.md
+++ b/docs/workflow/learnings.md
@@ -22,11 +22,11 @@
 
 ### 2026-03-24 — Issues governance workflow drifted from repo taxonomy and templates
 
-**Context**: Verifying the `v0.3.4` release surfaced repeated failures from `.github/workflows/issues-governance.yml` while the release itself was healthy.
+**Context**: Verifying the `v0.3.4` release surfaced repeated failures from the issue-governance workflow while the release itself was healthy.
 
 **Discovery**: The workflow had been enforcing an `area:*` label and rejecting prefixed issue titles, but this repository's documented governance model requires one taxonomy label, one priority label, and at least one domain label from the established set (`policy`, `psi`, `cgroup`, `oom`, `crostini`, `testing`, `performance`, `research`). At the same time, several shipped issue templates still defaulted to prefixed titles like `[Epic]` and `[Task]`, and some templates omitted the `Impact` / `Acceptance criteria` sections the workflow expected. In addition, GitHub was registering zero-job `push` runs against this workflow file; with no eligible jobs, those runs were marked failed and created more governance noise even though the real issue/schedule logic was fine. The result was self-inflicted governance noise: the workflow, docs, templates, and GitHub runtime behavior were contradicting one another.
 
-**Application**: Keep the governance workflow, issue templates, and contributor/admin docs aligned as one change set. For this repository, validate domain labels explicitly instead of `area:*`, keep issue titles plain imperative in templates, ensure every template includes `Problem` or `Objective`, `Impact`, and `Acceptance criteria`, and add an explicit green no-op guard for unsupported events so zero-job workflow runs cannot show up as false failures.
+**Application**: Keep the governance workflow, issue templates, and contributor/admin docs aligned as one change set. For this repository, validate domain labels explicitly instead of `area:*`, keep issue titles plain imperative in templates, ensure every template includes `Problem` or `Objective`, `Impact`, and `Acceptance criteria`, add an explicit green no-op guard for unsupported events, and reset the workflow file registration if GitHub keeps emitting zero-job false failures against a stale filename-keyed workflow.
 
 ---
 


### PR DESCRIPTION
## Summary
- rename the issues-governance workflow file to force a fresh GitHub workflow registration
- preserve the corrected domain-label/title/body governance rules
- document the stale filename-keyed workflow registration behavior in `docs/workflow/learnings.md`

## Validation
- `bash test-watchdog.sh`
- `bash -n mem-watchdog.sh`
- `shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh`
- `cd vscode-extension && npm test`
- open-issue governance audit: all open issues satisfy current rules
- latest stale `.github/workflows/issues-governance.yml` push runs show zero jobs, confirming registration corruption rather than current YAML logic

Closes #37
