### PR TITLE
fix(config): guarantee governance workflow job graph

### DIFF
--- a/.github/workflows/issue-governance.yml
+++ b/.github/workflows/issue-governance.yml
@@ -15,11 +15,10 @@ permissions:
 
 jobs:
   ignore_unexpected_event:
-    if: github.event_name != 'issues' && github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - name: Ignore unsupported event
-        run: echo "Skipping issues governance for unsupported event: ${GITHUB_EVENT_NAME}"
+      - name: Governance event bookkeeping
+        run: echo "Issues governance bookkeeping for event: ${GITHUB_EVENT_NAME}"
 
   validate_issue_event:
     if: github.event_name == 'issues'

--- a/.github/workflows/issues-governance.yml
+++ b/.github/workflows/issues-governance.yml
@@ -15,11 +15,10 @@ permissions:
 
 jobs:
   ignore_unexpected_event:
-    if: github.event_name != 'issues' && github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - name: Ignore unsupported event
-        run: echo "Skipping issues governance for unsupported event: ${GITHUB_EVENT_NAME}"
+      - name: Governance event bookkeeping
+        run: echo "Issues governance bookkeeping for event: ${GITHUB_EVENT_NAME}"
 
   validate_issue_event:
     if: github.event_name == 'issues'


### PR DESCRIPTION
## Summary
- make governance bookkeeping job unconditional so workflow runs always have at least one runnable job
- keep strict issue-event and scheduled-audit gates in place

## Validation
- `bash test-watchdog.sh`
- `bash -n mem-watchdog.sh`
- `shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh`
- `cd vscode-extension && npm test`

Closes #37
