### PR TITLE
fix(daemon): protect language servers and utility processes from kill_top_vscode_helper

### DIFF
--- a/mem-watchdog.sh
+++ b/mem-watchdog.sh
@@ -39,7 +39,7 @@ SIGTERM_THRESHOLD=25   # Kill Chrome with SIGTERM when MemAvailable < 25% (~1.6 
 SIGKILL_THRESHOLD=15   # Escalate to SIGKILL when MemAvailable < 15% (~945 MB)
 PSI_THRESHOLD=25       # Kill on sustained memory stall: PSI full avg10 > 25%
 INTERVAL=2             # Seconds between checks (was 4 — confirmed too slow in crash of 2026-03-05)
-export WATCHDOG_VERSION=20260324.2   # 2026-03-24 v2: protect htmlServerMain, serverWorkerMain, cssServerMain at WARN   # Bump on behavioral changes; used by extension installer to prevent downgrades
+export WATCHDOG_VERSION=20260324.3   # 2026-03-24 v3: fix accel mode, protect json/eslint servers, guard utility processes   # Bump on behavioral changes; used by extension installer to prevent downgrades
 OOM_VSCODE_ADJ=0       # oom_score_adj for VS Code: lowers Electron's default 200-300
 OOM_CHROME_ADJ=1000    # oom_score_adj for Chrome: maximum killable
 # VS Code RSS thresholds (confirmed: extension host hit 4 GB, watchdog had no Chrome to kill)
@@ -376,7 +376,7 @@ kill_top_vscode_helper() {
   #                        servers crashed 5x each in OOM cascade.
   # Only allow these as kill targets at "emerg" severity (true emergency).
   local protect_tsserver=true
-  local protect_langservers=true   # htmlServerMain, serverWorkerMain (markdown), cssServerMain
+  local protect_langservers=true   # htmlServerMain, serverWorkerMain (markdown), cssServerMain, jsonServerMain, eslintServer
   [[ "$mode" == "emerg" ]] && protect_tsserver=false
   [[ "$mode" == "emerg" ]] && protect_langservers=false
   local now
@@ -439,12 +439,12 @@ kill_top_vscode_helper() {
         if (args ~ /^\/usr\/share\/code\/code$/) next;
         if (args ~ /--type=zygote/) next;
         if (args ~ /--type=gpu-process/) next;
-        if (args ~ /--type=extensionHost/) next;
+        if (args ~ /--type=extensionHost/ || args ~ /--type=utility/) next;
         t=classify(args)
         if (skip != "" && t == skip) next;
         if (prot == "true" && t == "tsserver") next;
-        if (ls == "true" && (t == "html-server" || t == "markdown-server" || t == "css-server")) next;
-        if (args ~ /--node-ipc/ || args ~ /server\.bundle\.js/ || (args ~ /tsserver\.js/ && prot != "true") || args ~ /eslintServer\.js/ || args ~ /jsonServerMain/) {
+        if (ls == "true" && (t == "html-server" || t == "markdown-server" || t == "css-server" || t == "json-server" || t == "eslint")) next;
+        if (args ~ /--node-ipc/ || args ~ /server\.bundle\.js/ || (args ~ /tsserver\.js/ && prot != "true") || (args ~ /eslintServer\.js/ && ls != "true") || (args ~ /jsonServerMain/ && ls != "true")) {
           printf "%s %s %s\n", pid, rss, args;
         }
       }
@@ -468,11 +468,11 @@ kill_top_vscode_helper() {
           if (args ~ /^\/usr\/share\/code\/code$/) next;
           if (args ~ /--type=zygote/) next;
           if (args ~ /--type=gpu-process/) next;
-          if (args ~ /--type=extensionHost/) next;
+          if (args ~ /--type=extensionHost/ || args ~ /--type=utility/) next;
           t=classify(args)
           if (skip != "" && t == skip) next;
           if (prot == "true" && t == "tsserver") next;
-          if (ls == "true" && (t == "html-server" || t == "markdown-server" || t == "css-server")) next;
+          if (ls == "true" && (t == "html-server" || t == "markdown-server" || t == "css-server" || t == "json-server" || t == "eslint")) next;
           printf "%s %s %s\n", pid, rss, args;
         }
       ' | sort -k2 -rn | head -1)
@@ -487,9 +487,9 @@ kill_top_vscode_helper() {
           if (args ~ /^\/usr\/share\/code\/code$/) next;
           if (args ~ /--type=zygote/) next;
           if (args ~ /--type=gpu-process/) next;
-          if (args ~ /--type=extensionHost/) next;
+          if (args ~ /--type=extensionHost/ || args ~ /--type=utility/) next;
           if (prot == "true" && args ~ /tsserver\.js/) next;
-          if (ls == "true" && (args ~ /htmlServerMain/ || args ~ /serverWorkerMain/ || args ~ /cssServerMain/)) next;
+          if (ls == "true" && (args ~ /htmlServerMain/ || args ~ /serverWorkerMain/ || args ~ /cssServerMain/ || args ~ /jsonServerMain/ || args ~ /eslintServer/)) next;
           printf "%s %s %s\n", pid, rss, args;
         }' | sort -k2 -rn | head -1)
     [[ -n "$line" ]] && log "  Anti-respawn: no alternative found — re-using last-killed type"
@@ -771,7 +771,13 @@ while true; do
         _runaway_streak=$(( _runaway_streak + 1 ))
       fi
       if [[ -z "$chrome_running" ]]; then
-        kill_top_vscode_helper "RSS acceleration: +${_rss_delta} kB/cycle (${vscode_rss} kB total)" "emerg"
+        # Use normal mode (language-server protection ON) unless RSS has actually
+        # reached emergency level. Without this, WARN-range spikes (~2.2 GB)
+        # bypass all protection and kill language servers that only use ~80-120 MB.
+        # Fix: issue #45 — confirmed 2026-03-24 crash from emerg at WARN range.
+        accel_mode="normal"
+        (( vscode_rss >= eff_emerg )) && accel_mode="emerg"
+        kill_top_vscode_helper "RSS acceleration: +${_rss_delta} kB/cycle (${vscode_rss} kB total)" "$accel_mode"
       else
         kill_browsers "TERM" "RSS acceleration: +${_rss_delta} kB/cycle (${vscode_rss} kB total)"
       fi


### PR DESCRIPTION
## Summary

Three related bugs caused the watchdog to kill critical VS Code processes during non-emergency RSS spikes, crashing Copilot agent operations.

### Changes

**Fix 1 — RSS accel mode selection (Closes #45)**
- RSS acceleration path used `"emerg"` mode unconditionally, bypassing all language-server protection even at WARN-range RSS (~2.2 GB)
- Now uses `"normal"` mode below `eff_emerg`, `"emerg"` only at/above

**Fix 2 — Language server protection expansion (Closes #46)**
- Added `json-server` and `eslint` to `protect_langservers` guard in all 3 awk blocks
- Updated preferred block filter to exclude protected servers when `ls != "true"`
- jsonServerMain was killed 5× in 2 min on 2026-03-24, hitting VS Code's permanent 5-crash death threshold

**Fix 3 — Utility process guard (Closes #47)**
- VS Code 1.90+ runs Extension Host as `--type=utility`, not `--type=extensionHost`
- The 489 MB process hosting Copilot Chat, Playwright MCP, and all extensions was invisible to the existing guard
- Added `--type=utility` exclusion across all three awk blocks

### Gate Suite Evidence

| Gate | Result |
|---|---|
| `bash -n mem-watchdog.sh` | ✅ SYNTAX OK |
| `shellcheck --shell=bash -e SC1091,SC2317` | ✅ Clean |
| `bash test-watchdog.sh` | ✅ 15/15 passed |
| `npm test` | ✅ 56/56 passed |

### Risk Assessment

**Low risk** — changes are confined to the `kill_top_vscode_helper` function's candidate selection logic and the RSS accel caller. No threshold changes, no new kill paths, no config format changes.

Closes #45, Closes #46, Closes #47