### PR TITLE
chore(ci): remove push trigger from issues-governance workflow

### DIFF
--- a/.github/workflows/issues-governance.yml
+++ b/.github/workflows/issues-governance.yml
@@ -1,8 +1,6 @@
 name: Issues Governance
 
 on:
-  push:
-    branches: [main]
   issues:
     types: [opened, edited, reopened, labeled, unlabeled]
   schedule:
@@ -14,12 +12,6 @@ permissions:
   contents: read
 
 jobs:
-  ignore_unexpected_event:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Governance event bookkeeping
-        run: echo "Issues governance bookkeeping for event: ${GITHUB_EVENT_NAME}"
-
   validate_issue_event:
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest


### PR DESCRIPTION
The issues-governance workflow triggers on `issues`, `schedule`, and `workflow_dispatch` events. It has no meaningful jobs for `push` — the only push-triggered job was a no-op echo. GitHub registers a zero-job run on every push and marks it as failed, creating noise in the Actions tab. Removes the `push` trigger and the no-op `ignore_unexpected_event` job.