### PR TITLE
docs: fix stale test counts and vsix version in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ All 4 gates must pass before any change is published:
 
 ```bash
 bash test-watchdog.sh              # 15 bash tests (~3 s) — service, OOM scores, PSI, SwapFree safety, SIGTERM
-cd vscode-extension && npm test    # 56 JS unit tests (~1 s) — extension state machine, activation singleton, pileup guard, utils
+cd vscode-extension && npm test    # 75 JS unit tests (~1 s) — extension state machine, activation singleton, pileup guard, utils
 bash -n mem-watchdog.sh            # bash syntax check
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh
 ```

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -124,7 +124,7 @@ cd vscode-extension
 npm run build
 npm install -g @vscode/vsce
 vsce package
-code --install-extension mem-watchdog-status-0.3.4.vsix
+code --install-extension mem-watchdog-status-0.3.6.vsix
 ```
 
 Reload the window (`Developer: Reload Window`). The daemon installs and starts automatically on first activation.
@@ -151,9 +151,9 @@ Commercial use requires a paid license. See [COMMERCIAL-LICENSE.md](https://gith
 git clone https://github.com/chf3198/crostini-mem-watchdog.git
 cd crostini-mem-watchdog/vscode-extension
 npm run build          # populate resources/ from repo root
-npm test               # 56 JS unit tests via node:test (zero-install)
+npm test               # 75 JS unit tests via node:test (zero-install)
 npm run test:coverage  # same + c8 V8 coverage report
 npm run test:stress    # stress scenarios: pileup guard, EL lag, heap usage
 ```
 
-56 unit tests covering `readMeminfo`/`readPsi`/`sh()`/`checkServiceStatus()`, config validation, command handlers, installer decision logic, `activate()` singleton lifecycle, and the `update()` state machine + pileup guard.
+75 unit tests covering `readMeminfo`/`readPsi`/`sh()`/`checkServiceStatus()`, config validation, command handlers, installer decision logic, `activate()` singleton lifecycle, the `update()` state machine + pileup guard, update checker (version comparison, throttling, dismissal), and installer MIN_SAFE_DAEMON_VERSION guard.


### PR DESCRIPTION
docs-drift-maintenance detected 3 stale references after #55 post-merge governance:

- `README.md`: '56 JS unit tests' → '75 JS unit tests' in validation section
- `vscode-extension/README.md`: '56' → '75' in contributing section  
- `vscode-extension/README.md`: `mem-watchdog-status-0.3.4.vsix` → `0.3.6.vsix` in install command