### PR TITLE
feat(daemon): define process classification tiers (#6)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@
 mem-watchdog.sh          ← core daemon; single infinite loop, no deps beyond coreutils
 mem-watchdog.service     ← systemd user unit (systemctl --user, NOT system)
 install.sh               ← shell-only installer (no VS Code required)
-test-watchdog.sh         ← 15-test suite; exits 0/1; logs to scratch/
+test-watchdog.sh         ← 16-test suite; exits 0/1; logs to scratch/
 vscode-extension/
   extension.js           ← activate(): install → config → commands → status bar (2s poll) → update check
   installer.js           ← SHA-256 hash-based daemon auto-install/upgrade + MIN_SAFE guard
@@ -70,7 +70,7 @@ EXPLORE → PLAN → IMPLEMENT → GATE → REFLECT → COMMIT
 **GATE**: All five checks must exit 0 — no exceptions, no skips:
 
 ```bash
-bash test-watchdog.sh                                                          # 15 bash tests, ~3s
+bash test-watchdog.sh                                                          # 16 bash tests, ~3s
 bash -n mem-watchdog.sh                                                        # syntax check
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh
 cd vscode-extension && npm test                                                # 75 JS unit tests, ~1s
@@ -91,7 +91,7 @@ npm run test:coverage      # + c8 V8 lcov output
 npm run test:stress        # pileup guard + event-loop lag + heap scenarios
 npx vsce package           # → mem-watchdog-status-x.y.z.vsix
 
-bash test-watchdog.sh      # 15 bash tests (repo root — REPO=$(dirname $0), not scripts/)
+bash test-watchdog.sh      # 16 bash tests (repo root — REPO=$(dirname $0), not scripts/)
 bash test-pressure.sh      # live memory allocation tests; needs RAM < 40% free
 ./mem-watchdog.sh --dry-run
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Installs](https://img.shields.io/visual-studio-marketplace/i/CurtisFranks.mem-watchdog-status?color=00d4aa)](https://marketplace.visualstudio.com/items?itemName=CurtisFranks.mem-watchdog-status)
 [![License: PolyForm NC](https://img.shields.io/badge/License-PolyForm%20NC%201.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-ChromeOS%20Crostini-4285f4)](https://chromeos.dev/en/linux)
-[![Tests](https://img.shields.io/badge/bash-15%2F15-brightgreen)](test-watchdog.sh)
+[![Tests](https://img.shields.io/badge/bash-16%2F16-brightgreen)](test-watchdog.sh)
 [![Tests](https://img.shields.io/badge/js-75%2F75-brightgreen)](vscode-extension/package.json)
 
 _`earlyoom` hard-crashes on Crostini (exit 104, every 3 seconds, zero protection). This replaces it with a VS Code-aware watchdog that kills Chrome before the kernel OOM-kills VS Code._
@@ -102,7 +102,7 @@ crostini-mem-watchdog/
 ├── mem-watchdog.sh              ← core daemon (bash, coreutils only)
 ├── mem-watchdog.service         ← systemd user service unit
 ├── install.sh                   ← shell-only installer (no VS Code required)
-├── test-watchdog.sh             ← 15-test validation suite
+├── test-watchdog.sh             ← 16-test validation suite
 ├── test-pressure.sh             ← live memory pressure tests
 ├── watchdog-tray.sh             ← optional: yad system tray icon
 └── vscode-extension/            ← VS Code extension (primary install path)
@@ -155,7 +155,7 @@ crostini-mem-watchdog/
 All 4 gates must pass before any change is published:
 
 ```bash
-bash test-watchdog.sh              # 15 bash tests (~3 s) — service, OOM scores, PSI, SwapFree safety, SIGTERM
+bash test-watchdog.sh              # 16 bash tests (~3 s) — service, OOM scores, PSI, SwapFree safety, SIGTERM
 cd vscode-extension && npm test    # 75 JS unit tests (~1 s) — extension state machine, activation singleton, pileup guard, utils
 bash -n mem-watchdog.sh            # bash syntax check
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh

--- a/mem-watchdog.sh
+++ b/mem-watchdog.sh
@@ -65,9 +65,35 @@ STAGE4_MEM_PCT=15              # OR MemAvailable < 15%
 # configWriter.js (v0.3.x) writes these to ~/.config/mem-watchdog/config.sh.
 # After config sourcing below, they are mapped to stage constants.
 INTERVAL=2             # Seconds between checks (was 4 — confirmed too slow in crash of 2026-03-05)
-export WATCHDOG_VERSION=20260325.5   # 2026-03-25 v5: fix utility-process detection (#55)     # Bump on behavioral changes; used by extension installer to prevent downgrades
+export WATCHDOG_VERSION=20260325.6   # 2026-03-25 v6: process classification tiers (#6)     # Bump on behavioral changes; used by extension installer to prevent downgrades
 OOM_VSCODE_ADJ=0       # oom_score_adj for VS Code: lowers Electron's default 200-300
 OOM_CHROME_ADJ=1000    # oom_score_adj for Chrome: maximum killable
+
+# ── Process classification tiers (Issue #6) ──────────────────────────────────
+# Three tiers classify processes for oom_score_adj and kill-eligibility decisions.
+# Override patterns in ~/.config/mem-watchdog/config.sh to add custom processes.
+#
+# PROTECTED: VS Code core processes
+#   Matched by: ps -C $TIER_PROTECTED_PNAME (process name match)
+#   oom_score_adj: OOM_VSCODE_ADJ (0) — non-negative; no root needed
+#   Kill policy: never automatic; circuit-breaker only (kill_vscode_main at Stage 4)
+#
+# DISPOSABLE: browser and automation processes
+#   Matched by: pgrep -f $TIER_DISPOSABLE_PATTERN / $TIER_DISPOSABLE_PATTERN_AUX
+#   oom_score_adj: OOM_CHROME_ADJ (1000) — maximum kernel OOM priority
+#   Kill policy: Stage 2+ (Throttle and above)
+#
+# MONITORED: all other user processes (not actively managed by the watchdog)
+#   oom_score_adj: not modified; kill eligibility: not targeted
+#
+# Sub-tier refinement within protected (kill_top_vscode_helper):
+#   Extension Host: --inspect-port flag → excluded from helper kills entirely
+#   Language servers: protected at WARN severity, killable at EMERG only
+#   Other helpers (renderer, IPC): killable at WARN as expendable candidates
+TIER_PROTECTED_PNAME='code'                       # ps -C process name for protected tier
+TIER_DISPOSABLE_PATTERN='(chrome|chromium)'        # pgrep -f ERE for disposable browsers
+TIER_DISPOSABLE_PATTERN_AUX='node.*playwright'     # pgrep -f ERE for disposable automation
+
 # VS Code RSS thresholds (confirmed: extension host hit 4 GB, watchdog had no Chrome to kill)
 # Lower thresholds so we can intervene BEFORE the kernel OOM fires.
 VSCODE_RSS_EMERG_KB=3200000   # ~3.2 GB — emergency cutoff before kernel OOM territory
@@ -257,8 +283,8 @@ log_status_snapshot() {
   now=$(date +%s)
   avail=$(awk '/^MemAvailable:/{print $2; exit}' /proc/meminfo 2>/dev/null)
   total=$(awk '/^MemTotal:/{print $2; exit}' /proc/meminfo 2>/dev/null)
-  rss=$(ps -C code -o rss= 2>/dev/null | awk '{s+=$1} END{print s+0}')
-  chrome_count=$(pgrep -f '(chrome|chromium)' 2>/dev/null | wc -l)
+  rss=$(ps -C "$TIER_PROTECTED_PNAME" -o rss= 2>/dev/null | awk '{s+=$1} END{print s+0}')
+  chrome_count=$(pgrep -f "$TIER_DISPOSABLE_PATTERN" 2>/dev/null | wc -l)
   pct=0
   if [[ -n "$avail" && -n "$total" && "$total" -gt 0 ]]; then
     pct=$(( avail * 100 / total ))
@@ -343,11 +369,11 @@ kill_extension_host() {
   local exthost_pid
   # VS Code 1.90+: Extension Host runs as --type=utility with --inspect-port.
   # --inspect-port is present on exactly one utility process (the Extension Host).
-  exthost_pid=$(ps -C code -o pid=,args= 2>/dev/null \
+  exthost_pid=$(ps -C "$TIER_PROTECTED_PNAME" -o pid=,args= 2>/dev/null \
     | awk '$0 ~ /--type=utility/ && $0 ~ /--inspect-port/ {print $1; exit}')
   # Fallback: legacy VS Code uses --type=extensionHost
   if [[ -z "$exthost_pid" ]]; then
-    exthost_pid=$(ps -C code -o pid=,args= 2>/dev/null \
+    exthost_pid=$(ps -C "$TIER_PROTECTED_PNAME" -o pid=,args= 2>/dev/null \
       | awk '$0 ~ /--type=extensionHost/ {print $1; exit}')
   fi
   if [[ -z "$exthost_pid" ]]; then
@@ -380,9 +406,9 @@ kill_vscode_main() {
   fi
 
   local pid rss
-  pid=$(ps -C code -o pid=,args= 2>/dev/null | awk '$0 ~ /\/usr\/share\/code\/code$/ {print $1; exit}')
+  pid=$(ps -C "$TIER_PROTECTED_PNAME" -o pid=,args= 2>/dev/null | awk '$0 ~ /\/usr\/share\/code\/code$/ {print $1; exit}')
   if [[ -z "$pid" ]]; then
-    pid=$(ps -C code -o pid=,rss= 2>/dev/null | sort -k2 -rn | awk 'NR==1{print $1}')
+    pid=$(ps -C "$TIER_PROTECTED_PNAME" -o pid=,rss= 2>/dev/null | sort -k2 -rn | awk 'NR==1{print $1}')
   fi
   [[ -z "$pid" ]] && { log "  VS Code recovery: no code PID found"; return 1; }
 
@@ -422,11 +448,11 @@ kill_browsers() {
 
   local killed=false
 
-  if pkill "-${signal}" -f '(chrome|chromium)' 2>/dev/null; then
+  if pkill "-${signal}" -f "$TIER_DISPOSABLE_PATTERN" 2>/dev/null; then
     log "  → Chromium SIG${signal} sent"
     killed=true
   fi
-  if pkill "-${signal}" -f 'node.*playwright' 2>/dev/null; then
+  if pkill "-${signal}" -f "$TIER_DISPOSABLE_PATTERN_AUX" 2>/dev/null; then
     log "  → Playwright node SIG${signal} sent"
     killed=true
   fi
@@ -503,7 +529,7 @@ kill_top_vscode_helper() {
   fi
 
   # Preferred: language servers / extension workers, excluding recently-killed type
-  line=$(ps -C code -o pid=,rss=,args= 2>/dev/null \
+  line=$(ps -C "$TIER_PROTECTED_PNAME" -o pid=,rss=,args= 2>/dev/null \
     | awk -v skip="$skip_type" -v prot="$protect_tsserver" -v ls="$protect_langservers" '
       function classify(a) {
         if (a ~ /tsserver\.js/)        return "tsserver"
@@ -536,7 +562,7 @@ kill_top_vscode_helper() {
 
   # Fallback: any non-main, non-zygote, non-extensionHost child
   if [[ -z "$line" ]]; then
-    line=$(ps -C code -o pid=,rss=,args= 2>/dev/null \
+    line=$(ps -C "$TIER_PROTECTED_PNAME" -o pid=,rss=,args= 2>/dev/null \
       | awk -v skip="$skip_type" -v prot="$protect_tsserver" -v ls="$protect_langservers" '
         function classify(a) {
           if (a ~ /tsserver\.js/)      return "tsserver"
@@ -565,7 +591,7 @@ kill_top_vscode_helper() {
 
   # Last-resort fallback: include recently-killed type if nothing else found
   if [[ -z "$line" ]]; then
-    line=$(ps -C code -o pid=,rss=,args= 2>/dev/null \
+    line=$(ps -C "$TIER_PROTECTED_PNAME" -o pid=,rss=,args= 2>/dev/null \
       | awk -v prot="$protect_tsserver" -v ls="$protect_langservers" '{
           pid=$1; rss=$2;
           $1=""; $2=""; sub(/^[[:space:]]+/, "", $0); args=$0;
@@ -622,7 +648,7 @@ kill_top_vscode_helper() {
 adjust_oom_scores() {
   # Lower VS Code processes from Electron's default adj=200-300 down to 0
   # (No root needed — owner can write non-negative values to own processes)
-  for pid in $(ps -C code -o pid= 2>/dev/null); do
+  for pid in $(ps -C "$TIER_PROTECTED_PNAME" -o pid= 2>/dev/null); do
     local adj="/proc/$pid/oom_score_adj"
     [[ -w "$adj" ]] || continue
     [[ "$(cat "$adj" 2>/dev/null)" == "$OOM_VSCODE_ADJ" ]] && continue
@@ -634,7 +660,7 @@ adjust_oom_scores() {
   done
 
   # Condemn Chrome/Playwright to oom_score_adj=1000 (maximum killable, no root needed)
-  for pid in $(pgrep -f '(chrome|chromium)' 2>/dev/null; pgrep -f 'node.*playwright' 2>/dev/null); do
+  for pid in $(pgrep -f "$TIER_DISPOSABLE_PATTERN" 2>/dev/null; pgrep -f "$TIER_DISPOSABLE_PATTERN_AUX" 2>/dev/null); do
     local adj="/proc/$pid/oom_score_adj"
     [[ -w "$adj" ]] || continue
     [[ "$(cat "$adj" 2>/dev/null)" == "$OOM_CHROME_ADJ" ]] && continue
@@ -647,7 +673,7 @@ adjust_oom_scores() {
 
   # ── Detect new VS Code sessions → trigger startup mode ────────────────────
   local current_pids
-  current_pids=$(ps -C code -o pid= 2>/dev/null | sort | tr '\n' ' ')
+  current_pids=$(ps -C "$TIER_PROTECTED_PNAME" -o pid= 2>/dev/null | sort | tr '\n' ' ')
   if [[ -n "$current_pids" && "$current_pids" != "$_known_code_pids" ]]; then
     local new_count=0
     if [[ -n "$_known_code_pids" ]]; then
@@ -689,7 +715,7 @@ adjust_oom_scores() {
         _restart_timestamps="${_restart_timestamps} ${now}"
         log "VS Code startup: ${new_count} new PIDs — startup mode active for ${STARTUP_DURATION}s (${STARTUP_INTERVAL}s interval, ${STARTUP_RSS_EMERG_KB} kB emerg threshold)"
         # Pre-emptively SIGTERM Chrome to free memory before extensions load
-        if pgrep -f '(chrome|chromium)' &>/dev/null; then
+        if pgrep -f "$TIER_DISPOSABLE_PATTERN" &>/dev/null; then
           log "  Startup mode: pre-emptively SIGTERMing Chrome to free memory"
           kill_browsers "TERM" "VS Code startup: freeing memory before extension load"
         fi
@@ -698,6 +724,28 @@ adjust_oom_scores() {
       fi
     fi
     _known_code_pids="$current_pids"
+  fi
+}
+
+# ── Startup tier logging (Issue #6) ──────────────────────────────────────────
+# Log a summary of process-to-tier classification. Called once at daemon startup
+# after the first adjust_oom_scores pass so tier assignments are visible in the
+# journal for diagnostics.
+log_tier_assignments() {
+  local protected_pids disposable_pids aux_pids
+  local protected_count=0 disposable_count=0
+  protected_pids=$(ps -C "$TIER_PROTECTED_PNAME" -o pid= 2>/dev/null | tr '\n' ' ')
+  protected_count=$(echo "$protected_pids" | wc -w)
+  disposable_pids=$(pgrep -f "$TIER_DISPOSABLE_PATTERN" 2>/dev/null | tr '\n' ' ')
+  aux_pids=$(pgrep -f "$TIER_DISPOSABLE_PATTERN_AUX" 2>/dev/null | tr '\n' ' ')
+  disposable_pids="${disposable_pids}${aux_pids}"
+  disposable_count=$(echo "$disposable_pids" | wc -w)
+  log "TIER: protected=${protected_count} (${TIER_PROTECTED_PNAME}, adj=${OOM_VSCODE_ADJ}) disposable=${disposable_count} (adj=${OOM_CHROME_ADJ}) patterns: browser='${TIER_DISPOSABLE_PATTERN}' automation='${TIER_DISPOSABLE_PATTERN_AUX}'"
+  if (( protected_count > 0 )); then
+    log "TIER: protected PIDs: ${protected_pids}"
+  fi
+  if (( disposable_count > 0 )); then
+    log "TIER: disposable PIDs: ${disposable_pids}"
   fi
 }
 
@@ -731,7 +779,7 @@ check_restart_loop() {
 # Count Chrome/Chromium PIDs. SIGKILL oldest processes above CHROME_COUNT_MAX.
 check_chrome_cap() {
   local chrome_pids=()
-  mapfile -t chrome_pids < <(pgrep -f '(chrome|chromium)' 2>/dev/null | sort -n)
+  mapfile -t chrome_pids < <(pgrep -f "$TIER_DISPOSABLE_PATTERN" 2>/dev/null | sort -n)
   local count=${#chrome_pids[@]}
   if (( count > CHROME_COUNT_MAX )); then
     local excess=$(( count - CHROME_COUNT_MAX ))
@@ -910,6 +958,9 @@ $DRY_RUN && log "DRY-RUN mode — no processes will be killed"
 # Apply OOM scores immediately at startup before the first loop iteration
 adjust_oom_scores
 
+# Log tier assignments at startup for diagnostics (Issue #6)
+log_tier_assignments
+
 # Discover cgroup v1 memory path for Stage 2/3 interventions (Issue #4)
 discover_cgroup_mem_path
 
@@ -991,8 +1042,8 @@ while true; do
   # CONFIRMED CRASH (2026-03-05 13:02:25): extension host PID 778 hit 4 GB
   # RSS with no Chrome running. Watchdog had nothing to kill — VS Code died.
   # Fixes: lower thresholds, 2s interval, SIGTERM ext host as last resort.
-  vscode_rss=$(ps -C code -o rss= 2>/dev/null | awk '{s+=$1} END{print s+0}')
-  chrome_running=$(pgrep -f '(chrome|chromium)' 2>/dev/null | head -1)
+  vscode_rss=$(ps -C "$TIER_PROTECTED_PNAME" -o rss= 2>/dev/null | awk '{s+=$1} END{print s+0}')
+  chrome_running=$(pgrep -f "$TIER_DISPOSABLE_PATTERN" 2>/dev/null | head -1)
 
   # ── RSS velocity check — detect runaway growth (≥RSS_ACCEL_KB/cycle) ──
   # 2026-03-13 crash: RSS grew 3.8→6.0 GB in ~20s (300 MB/cycle at 2s). Watchdog

--- a/test-watchdog.sh
+++ b/test-watchdog.sh
@@ -250,6 +250,37 @@ else
   FAIL "Startup burst safe-skip fallback missing"
 fi
 
+# ── TEST 16: Process classification tier constants and logging (Issue #6) ────
+tee_log ""
+tee_log "── Test 16: Process classification tiers present"
+tier_ok=true
+if ! grep -q 'TIER_PROTECTED_PNAME=' "$WATCHDOG"; then
+  tee_log "    Missing TIER_PROTECTED_PNAME"
+  tier_ok=false
+fi
+if ! grep -q 'TIER_DISPOSABLE_PATTERN=' "$WATCHDOG"; then
+  tee_log "    Missing TIER_DISPOSABLE_PATTERN"
+  tier_ok=false
+fi
+if ! grep -q 'TIER_DISPOSABLE_PATTERN_AUX=' "$WATCHDOG"; then
+  tee_log "    Missing TIER_DISPOSABLE_PATTERN_AUX"
+  tier_ok=false
+fi
+if ! grep -q 'log_tier_assignments' "$WATCHDOG"; then
+  tee_log "    Missing log_tier_assignments function or call"
+  tier_ok=false
+fi
+# Verify patterns are used (not just defined) — at least one pgrep/ps uses a TIER_ var
+if ! grep -q 'TIER_DISPOSABLE_PATTERN"' "$WATCHDOG"; then
+  tee_log "    TIER_DISPOSABLE_PATTERN defined but not used in pgrep/pkill"
+  tier_ok=false
+fi
+if $tier_ok; then
+  PASS "Tier constants defined (TIER_PROTECTED_PNAME, TIER_DISPOSABLE_PATTERN, TIER_DISPOSABLE_PATTERN_AUX) and log_tier_assignments present"
+else
+  FAIL "Tier classification incomplete"
+fi
+
 # ── SUMMARY ──────────────────────────────────────────────────────────────────
 tee_log ""
 tee_log "════════════════════════════════════════════════════════════════"


### PR DESCRIPTION
## Summary

Formalizes the existing ad-hoc process classification into a configurable three-tier system:

| Tier | oom_score_adj | Kill eligible | Pattern constant |
|------|--------------|---------------|-----------------|
| **protected** | 0 | Never (circuit-breaker only) | `TIER_PROTECTED_PNAME` |
| **disposable** | 1000 | Stage 2+ | `TIER_DISPOSABLE_PATTERN` / `TIER_DISPOSABLE_PATTERN_AUX` |
| **monitored** | not modified | not targeted | (implicit — all other user processes) |

### Changes
- Add `TIER_PROTECTED_PNAME`, `TIER_DISPOSABLE_PATTERN`, `TIER_DISPOSABLE_PATTERN_AUX` constants (overridable via `~/.config/mem-watchdog/config.sh`)
- Replace 13 hardcoded pattern strings across `adjust_oom_scores`, `kill_browsers`, `check_chrome_cap`, startup mode, `kill_top_vscode_helper`, `kill_extension_host`, `kill_vscode_main`, and main loop
- Add `log_tier_assignments()` function called at daemon startup — tier summary visible in journal
- Add Test 16 (tier constants presence + usage validation)
- Bump `WATCHDOG_VERSION` to `20260325.6`
- Update bash test count 15→16 in README + copilot-instructions

### Design decisions
- **adj=0 for protected (not -500)**: Constraint #5 requires non-negative oom_score_adj — no root/sudo for adj writes. The circuit-breaker (`kill_vscode_main`) is an independent safety mechanism, not a tier policy.
- **Sub-tier refinement** within protected stays in kill functions: Extension Host excluded by `--inspect-port`, language servers protected at WARN/killable at EMERG. These are kill-function-internal decisions, not tier-level.
- **Kill functions unchanged**: Only the detection/enumeration patterns (`ps -C`, `pgrep -f`, `pkill -f`) use tier constants. The awk blocks inside kill functions retain their tested cmdline matching.

### Gate evidence
```
bash test-watchdog.sh     → 16/16 ✅
bash -n mem-watchdog.sh   → clean ✅
shellcheck mem-watchdog.sh → clean ✅
npm test                  → 75/75 ✅
docs-integrity-check.sh  → 4/4 ✅
```

Closes #6