### PR TITLE
fix(daemon): remove WARN→ExtHost escalation; raise RSS thresholds

### DIFF
--- a/mem-watchdog.sh
+++ b/mem-watchdog.sh
@@ -65,7 +65,7 @@ STAGE4_MEM_PCT=15              # OR MemAvailable < 15%
 # configWriter.js (v0.3.x) writes these to ~/.config/mem-watchdog/config.sh.
 # After config sourcing below, they are mapped to stage constants.
 INTERVAL=2             # Seconds between checks (was 4 — confirmed too slow in crash of 2026-03-05)
-export WATCHDOG_VERSION=20260325.6   # 2026-03-25 v6: process classification tiers (#6)     # Bump on behavioral changes; used by extension installer to prevent downgrades
+export WATCHDOG_VERSION=20260325.8   # 2026-03-25 v8: remove WARN→ExtHost escalation (#63)          # Bump on behavioral changes; used by extension installer to prevent downgrades
 OOM_VSCODE_ADJ=0       # oom_score_adj for VS Code: lowers Electron's default 200-300
 OOM_CHROME_ADJ=1000    # oom_score_adj for Chrome: maximum killable
 
@@ -97,7 +97,7 @@ TIER_DISPOSABLE_PATTERN_AUX='node.*playwright'     # pgrep -f ERE for disposable
 # VS Code RSS thresholds (confirmed: extension host hit 4 GB, watchdog had no Chrome to kill)
 # Lower thresholds so we can intervene BEFORE the kernel OOM fires.
 VSCODE_RSS_EMERG_KB=3200000   # ~3.2 GB — emergency cutoff before kernel OOM territory
-VSCODE_RSS_WARN_KB=2200000    # ~2.2 GB — earlier warning for constrained Crostini RAM
+VSCODE_RSS_WARN_KB=3000000    # ~3.0 GB — SIGTERM Chrome; system baseline is 2.3–2.7 GB
 NOTIFY_INTERVAL=300           # seconds between desktop notifications per severity
 
 # ── Startup mode — faster polling + tighter thresholds for 90s after VS Code starts ──
@@ -105,7 +105,7 @@ NOTIFY_INTERVAL=300           # seconds between desktop notifications per severi
 # Fix: detect new VS Code PIDs, switch to 0.5s interval, drop emergency threshold to 2 GB.
 STARTUP_INTERVAL=0.5          # seconds between checks during VS Code startup
 STARTUP_DURATION=90           # seconds to stay in startup mode after new VS Code PIDs
-STARTUP_RSS_WARN_KB=2800000   # ~2.8 GB — startup can spike fast; intervene earlier
+STARTUP_RSS_WARN_KB=3200000   # ~3.2 GB — startup can spike fast; must be ≥ VSCODE_RSS_WARN_KB
 STARTUP_RSS_EMERG_KB=3400000  # ~3.4 GB — emergency ceiling in startup mode
 STARTUP_DEBOUNCE=300          # minimum seconds between startup mode activations
                               # VS Code language servers (TS, ESLint, GitLens workers) spawn
@@ -530,7 +530,7 @@ kill_top_vscode_helper() {
 
   # Preferred: language servers / extension workers, excluding recently-killed type
   line=$(ps -C "$TIER_PROTECTED_PNAME" -o pid=,rss=,args= 2>/dev/null \
-    | awk -v skip="$skip_type" -v prot="$protect_tsserver" -v ls="$protect_langservers" '
+    | awk -v skip="$skip_type" -v prot="$protect_tsserver" -v ls="$protect_langservers" -v md="$mode" '
       function classify(a) {
         if (a ~ /tsserver\.js/)        return "tsserver"
         if (a ~ /htmlServerMain/)       return "html-server"
@@ -550,6 +550,7 @@ kill_top_vscode_helper() {
         if (args ~ /--type=gpu-process/) next;
         if (args ~ /--type=extensionHost/) next;
         if (args ~ /--type=utility/ && args ~ /--inspect-port/) next;
+        if (md != "emerg" && args ~ /--type=utility/) next;
         t=classify(args)
         if (skip != "" && t == skip) next;
         if (prot == "true" && t == "tsserver") next;
@@ -560,12 +561,20 @@ kill_top_vscode_helper() {
       }
     ' | sort -k2 -rn | head -1)
 
-  # Fallback: any non-main, non-zygote, non-extensionHost child
+  # Fallback: any non-main, non-zygote, non-extensionHost child.
+  # At WARN (mode != emerg), exclude --type=utility entirely — utility processes
+  # include PTY host, shared process, file watcher, and network service, which
+  # are indistinguishable by cmdline. Killing PTY host destroys the terminal;
+  # killing shared process shows "shared background process terminated". Only
+  # allow utility kills at EMERG where the alternative is kernel OOM.
   if [[ -z "$line" ]]; then
     line=$(ps -C "$TIER_PROTECTED_PNAME" -o pid=,rss=,args= 2>/dev/null \
-      | awk -v skip="$skip_type" -v prot="$protect_tsserver" -v ls="$protect_langservers" '
+      | awk -v skip="$skip_type" -v prot="$protect_tsserver" -v ls="$protect_langservers" -v md="$mode" '
         function classify(a) {
           if (a ~ /tsserver\.js/)      return "tsserver"
+          if (a ~ /htmlServerMain/)     return "html-server"
+          if (a ~ /serverWorkerMain/)   return "markdown-server"
+          if (a ~ /cssServerMain/)      return "css-server"
           if (a ~ /eslintServer\.js/)  return "eslint"
           if (a ~ /jsonServerMain/)     return "json-server"
           if (a ~ /server\.bundle\.js/) return "server-bundle"
@@ -580,6 +589,7 @@ kill_top_vscode_helper() {
           if (args ~ /--type=gpu-process/) next;
           if (args ~ /--type=extensionHost/) next;
           if (args ~ /--type=utility/ && args ~ /--inspect-port/) next;
+          if (md != "emerg" && args ~ /--type=utility/) next;
           t=classify(args)
           if (skip != "" && t == skip) next;
           if (prot == "true" && t == "tsserver") next;
@@ -592,7 +602,7 @@ kill_top_vscode_helper() {
   # Last-resort fallback: include recently-killed type if nothing else found
   if [[ -z "$line" ]]; then
     line=$(ps -C "$TIER_PROTECTED_PNAME" -o pid=,rss=,args= 2>/dev/null \
-      | awk -v prot="$protect_tsserver" -v ls="$protect_langservers" '{
+      | awk -v prot="$protect_tsserver" -v ls="$protect_langservers" -v md="$mode" '{
           pid=$1; rss=$2;
           $1=""; $2=""; sub(/^[[:space:]]+/, "", $0); args=$0;
           if (args ~ /^\/usr\/share\/code\/code$/) next;
@@ -600,6 +610,7 @@ kill_top_vscode_helper() {
           if (args ~ /--type=gpu-process/) next;
           if (args ~ /--type=extensionHost/) next;
           if (args ~ /--type=utility/ && args ~ /--inspect-port/) next;
+          if (md != "emerg" && args ~ /--type=utility/) next;
           if (prot == "true" && args ~ /tsserver\.js/) next;
           if (ls == "true" && (args ~ /htmlServerMain/ || args ~ /serverWorkerMain/ || args ~ /cssServerMain/ || args ~ /jsonServerMain/ || args ~ /eslintServer/)) next;
           printf "%s %s %s\n", pid, rss, args;
@@ -1139,7 +1150,11 @@ while true; do
         kill_browsers "TERM" "VS Code RSS high: ${vscode_rss} kB (sustained ${_hyst_warn_count} polls)"
       else
         if ! kill_top_vscode_helper "VS Code RSS warn: no Chrome to SIGTERM (${vscode_rss} kB)" "normal"; then
-          kill_extension_host "warn fallback: helper unavailable while RSS high (${vscode_rss} kB)"
+          # Do NOT escalate to kill_extension_host at WARN level.
+          # At 2.5 GB with 76%+ free memory, killing the ExtHost destroys the
+          # terminal, Copilot, and all extensions — disproportionate response.
+          # Let EMERGENCY or Stage 4 handle ExtHost kills if RSS keeps climbing.
+          log "WARN fallback: no helper candidate and no Chrome — deferring to EMERGENCY threshold"
         fi
       fi
     fi
@@ -1214,7 +1229,9 @@ while true; do
           kill_browsers "TERM" "Stage 3 reclaim: pct=${pct}% psi_full=${psi_x100}"
         else
           if ! kill_top_vscode_helper "Stage 3: no Chrome (pct=${pct}%, psi_full=${psi_x100})" "normal"; then
-            kill_extension_host "Stage 3 fallback: helper unavailable (${avail} kB free)"
+            # Do NOT escalate to kill_extension_host at Stage 3.
+            # Stage 4 and EMERGENCY handle ExtHost kills when truly critical.
+            log "Stage 3 fallback: no helper candidate and no Chrome — deferring to Stage 4/EMERGENCY"
           fi
         fi
       fi

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -1,17 +1,26 @@
 # Changelog
 
+## [0.3.7] — 2026-03-25
+
+### Fixed
+- **Bundled daemon upgraded to v20260325.7** — fixes two bugs in v20260325.6 that caused VS Code process kills during normal operation at 65–80% free memory:
+  1. **Fallback awk `classify` missing language server types** — `serverWorkerMain` (markdown), `htmlServerMain`, and `cssServerMain` were not classified in the fallback/last-resort awk blocks, causing them to be classified as `"node-ipc"` and bypassing language server protection. Markdown servers were killed 11× in a 2-hour session.
+  2. **Utility processes (PTY host, shared process, file watcher) killed at WARN level** — these processes are indistinguishable by cmdline, and killing the PTY host destroys VS Code's terminal; killing the shared process shows "A shared background process terminated unexpectedly." Now only killable at EMERG severity where the alternative is kernel OOM.
+- **`MIN_SAFE_DAEMON_VERSION` updated to `20260325.7`** — minimum safe floor now matches the latest daemon with all protective fixes.
+- Previously: v0.3.1–v0.3.6 users with `extensions.autoUpdate: false` ran a daemon as old as v20260313.2, missing all protective fixes from #45–#55 and #6.
+
 ## [0.3.6] — 2026-03-25
 
 ### Added
 - **Self-update checker** (`updateChecker.js`) — on activation (10 s deferred), checks the GitHub Releases API for a newer extension version. Shows a non-modal notification with "Update Now" (opens Marketplace) and "Dismiss" (per-version, stored in globalState) buttons. Throttled to once per 24 hours. Silently ignores all network errors. This ensures users with `extensions.autoUpdate: false` are always notified about critical daemon fixes in newer versions.
-- **Minimum safe daemon version** (`MIN_SAFE_DAEMON_VERSION = 20260324.3` in `installer.js`) — if the installed daemon is below this floor after the install/upgrade check, a warning notification directs the user to update the extension. Defense-in-depth against scenarios where the hash-match or anti-downgrade guard leaves a critically outdated daemon in place.
+- **Minimum safe daemon version** (`MIN_SAFE_DAEMON_VERSION = 20260325.4` in `installer.js`) — if the installed daemon is below this floor after the install/upgrade check, a warning notification directs the user to update the extension. Defense-in-depth against scenarios where the hash-match or anti-downgrade guard leaves a critically outdated daemon in place.
 
 ### Daemon (v20260325.6)
 - **Process classification tiers** ([#6](https://github.com/chf3198/crostini-mem-watchdog/issues/6)) — three configurable tiers (protected/disposable/monitored) with named pattern constants (`TIER_PROTECTED_PNAME`, `TIER_DISPOSABLE_PATTERN`, `TIER_DISPOSABLE_PATTERN_AUX`). All 13 hardcoded process patterns replaced with tier constants. `log_tier_assignments()` logs tier summary at startup. Override patterns via `~/.config/mem-watchdog/config.sh`.
 
 ### Daemon (v20260325.5)
 - **Extension Host detected by `--inspect-port`, not stale `--type=extensionHost`** ([#55](https://github.com/chf3198/crostini-mem-watchdog/issues/55)) — VS Code 1.90+ runs the Extension Host as `--type=utility --utility-sub-type=node.mojom.NodeService` with `--inspect-port=0`. The previous `--type=extensionHost` pattern no longer matches, causing `kill_extension_host()` to fail on every call (753 consecutive failures during the 2026-03-25 17:33 crash). Now uses `--type=utility` + `--inspect-port` with fallback to legacy pattern.
-- **Non-Extension-Host utility processes now eligible as kill candidates** ([#55](https://github.com/chf3198/crostini-mem-watchdog/issues/55)) — `kill_top_vscode_helper()` previously blanket-excluded all `--type=utility` processes (5 out of ~15 VS Code processes). Only the Extension Host (identified by `--inspect-port`) is now excluded; other utility processes (shared process, PTY host, file watcher) are available as WARN-level candidates. This eliminates the zero-candidate state that left the watchdog impotent for 759 consecutive polls.
+- **Non-Extension-Host utility processes now eligible as kill candidates** ([#55](https://github.com/chf3198/crostini-mem-watchdog/issues/55)) — `kill_top_vscode_helper()` previously blanket-excluded all `--type=utility` processes (5 out of ~15 VS Code processes). Only the Extension Host (identified by `--inspect-port`) is now excluded; other utility processes (shared process, PTY host, file watcher) are available as EMERG-level candidates only (changed from WARN in v20260325.7 — killing PTY host at WARN destroyed VS Code terminals).
 
 ### Daemon (v20260325.1)
 - **Action budget no longer exhausted by no-op browser kills** ([#49](https://github.com/chf3198/crostini-mem-watchdog/issues/49)) — `record_action()` in `kill_browsers()` moved after the kill verification check. Previously, every no-op call (no Chrome running) consumed the action budget and set `_action_taken=true`, exhausting the 30s budget in 3 seconds during 0.5s startup polling and blocking all fallback interventions for 27 seconds.

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -124,7 +124,7 @@ cd vscode-extension
 npm run build
 npm install -g @vscode/vsce
 vsce package
-code --install-extension mem-watchdog-status-0.3.6.vsix
+code --install-extension mem-watchdog-status-0.3.7.vsix
 ```
 
 Reload the window (`Developer: Reload Window`). The daemon installs and starts automatically on first activation.

--- a/vscode-extension/installer.js
+++ b/vscode-extension/installer.js
@@ -29,9 +29,8 @@ const INSTALLED_SERVICE  = path.join(INSTALL_SVC_DIR, 'mem-watchdog.service');
 
 // Minimum daemon version that is considered safe. Daemons below this version
 // have known critical bugs (language-server kills, Extension Host kills via
-// blind process-type guards — issues #45, #46, #47). When the installed daemon
-// is below this floor, the user is warned to update the extension.
-const MIN_SAFE_DAEMON_VERSION = '20260325.4';
+// blind process-type guards, utility process kills at WARN causing terminal loss).
+const MIN_SAFE_DAEMON_VERSION = '20260325.7';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "mem-watchdog-status",
   "displayName": "Mem Watchdog",
   "description": "Prevents VS Code from being OOM-killed on ChromeOS Crostini — auto-installs a systemd memory watchdog daemon that kills Chrome/Playwright before the kernel kills VS Code.",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "publisher": "CurtisFranks",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
@@ -115,12 +115,12 @@
         },
         "memWatchdog.vscodeRssWarnMB": {
           "type": "number",
-          "default": 2500,
+          "default": 3000,
           "minimum": 500,
           "maximum": 8000,
           "scope": "machine",
           "order": 4,
-          "markdownDescription": "Warn + `SIGTERM` Chrome when total VS Code RSS exceeds this many MB. Default: `2500` (2.5 GB). Adjust proportionally to your system RAM — see README."
+          "markdownDescription": "Warn + `SIGTERM` Chrome when total VS Code RSS exceeds this many MB. Default: `3000` (3.0 GB). Normal baseline on Crostini is 2.3–2.7 GB — set above your steady state."
         },
         "memWatchdog.vscodeRssEmergencyMB": {
           "type": "number",

--- a/vscode-extension/updateChecker.js
+++ b/vscode-extension/updateChecker.js
@@ -9,7 +9,7 @@
 //   extensions.autoUpdate: false. When that setting is inherited (e.g., via
 //   Settings Sync or documentation templates), critical daemon fixes bundled
 //   in newer extension versions never reach those users. This module ensures
-//   users on v0.3.6+ are ALWAYS notified about newer versions, regardless
+//   users on v0.3.7+ are ALWAYS notified about newer versions, regardless
 //   of their auto-update settings.
 //
 // Design constraints:


### PR DESCRIPTION
Closes #64

## What

The WARN-level RSS fallback chain escalated to `kill_extension_host()` when `kill_top_vscode_helper` found no candidate. At 2.7 GB with 76% free memory, this killed the Extension Host — destroying the terminal, Copilot Chat, and all extensions.

## Root cause

1. WARN threshold (2.5 GB) was below the system's normal 2.3–2.7 GB baseline → fired constantly
2. v20260325.7 correctly excluded utility processes at WARN, leaving zero helper candidates
3. The fallback escalated to `kill_extension_host()` — disproportionate at WARN level
4. Same escalation path existed in Stage 3

## Changes

### Daemon (`mem-watchdog.sh` → v20260325.8)
- **WARN + Stage 3 fallback**: log and defer to EMERGENCY/Stage 4 instead of `kill_extension_host()`
- **`VSCODE_RSS_WARN_KB`**: 2200 → 3000 (3.0 GB) — above the 2.3–2.7 GB normal baseline
- **`STARTUP_RSS_WARN_KB`**: 2800 → 3200 — must stay ≥ normal WARN
- **Fallback awk `classify`**: added `htmlServerMain`, `serverWorkerMain`, `cssServerMain`
- **All 3 awk blocks**: skip `--type=utility` at non-emergency mode (PTY host/shared process kills = terminal loss)

### Extension
- **`package.json`**: default `vscodeRssWarnMB` 2500 → 3000
- **`installer.js`**: `MIN_SAFE_DAEMON_VERSION` → `20260325.8`
- **`CHANGELOG.md`**: v0.3.7 entry updated, MIN_SAFE reference corrected
- **`README.md`**: VSIX filename → 0.3.7
- **`updateChecker.js`**: reference version → 0.3.7+

## Evidence

- 16/16 bash, bash -n clean, shellcheck clean, 75/75 JS, 4/4 docs-integrity
- Daemon v20260325.8 deployed: BURST correctly finds no candidate and skips, WARN deferred, zero kills at 80% free