### PR TITLE
docs(daemon): add crash history for 2026-03-26 WARN→ExtHost escalation

### DIFF
--- a/docs/technical/system-stability.md
+++ b/docs/technical/system-stability.md
@@ -171,6 +171,8 @@ Setting this to **512 MB** (the original value) was counterproductive:
 | 2026-03-25 post-fix | 0 | Daemon v20260325.1: no-ops don't consume budget, `chrome_running` checked before `kill_browsers`, `STARTUP_BURST_RSS_KB` raised to 2.2 GB |
 | 2026-03-25 17:33 | 2 | Watchdog blind at WARN level for 25 min: `kill_top_vscode_helper` blanket-excluded `--type=utility` (759 no-candidate polls), `kill_extension_host` used stale `--type=extensionHost` pattern (753 failed escalations). RSS grew 2.5→3.58 GB → EMERGENCY `kill_vscode_main`. (issue #55, daemon v20260325.5) |
 | 2026-03-25 post-#55 | 0 | Daemon v20260325.5: Extension Host identified by `--type=utility` + `--inspect-port`; other utility processes now eligible kill candidates; `helper_no_candidate=0` |
+| 2026-03-26 00:00:18 | 2 | WARN→ExtHost escalation: `kill_extension_host()` fired at 2.7 GB RSS / 76% free memory. WARN threshold (2.2–2.56 GB) was below normal baseline (2.3–2.7 GB), so WARN fired constantly. `kill_top_vscode_helper` found no candidate (utility processes correctly excluded), fell through to `kill_extension_host()` — destroyed terminal, Copilot, all extensions. ExtHost restart triggered extension v0.3.1 installer → overwrote daemon v20260325.7 with v20260313.2 (12 days old) → old daemon BURST-killed tsserver at 75% free. (issue #64, daemon v20260325.8) |
+| 2026-03-26 post-#64 | 0 | Daemon v20260325.8: WARN and Stage 3 no longer escalate to `kill_extension_host()` — log and defer to EMERGENCY/Stage 4. `VSCODE_RSS_WARN_KB` raised 2.2→3.0 GB. `STARTUP_RSS_WARN_KB` raised 2.8→3.2 GB. Utility processes excluded at non-emergency in all 3 awk blocks. |
 
 ### The 2026-03-05 crash — what was fixed
 
@@ -192,6 +194,7 @@ Three root causes:
 | ChromeOS zram 16 GB | Pathway #2 only — host-level balloon pressure | ✅ Active |
 | Action-budget no-op fix (v20260325.1) | Pathway #1 — no-op `kill_browsers()` no longer exhausts budget; fallback kills always reachable | ✅ Fixed |
 | Utility-process detection fix (v20260325.5) | Pathway #1 — Extension Host identified by `--inspect-port`; non-ExtHost utility processes eligible as kill candidates; `kill_extension_host()` finds modern Extension Host | ✅ Fixed |
+| WARN-deferral fix (v20260325.8) | Pathway #1 — WARN and Stage 3 no longer escalate to `kill_extension_host()`; defer to EMERGENCY/Stage 4. WARN threshold raised to 3.0 GB (above steady-state baseline). Prevents watchdog from destroying its own editing session at non-emergency RSS. | ✅ Fixed |
 | Container swap | Pathway #1 — direct relief for container kernel OOM | ❌ Blocked (CapEff=0, see §4) |
 
 **Residual risk:** The container kernel can still OOM if VS Code + idle MCP browser + a Playwright session all run simultaneously without the MCP browser being killed first. The watchdog mitigates this but cannot guarantee prevention if the spike is faster than the 2s polling interval.


### PR DESCRIPTION
Adds crash history entries to `system-stability.md` §8 and a new WARN-deferral mitigation row to §9.

**Changes:**
- Crash entry: 2026-03-26 00:00:18 — WARN→ExtHost escalation at 2.7 GB RSS / 76% free
- Post-fix entry: v20260325.8 — WARN/Stage 3 defer to EMERGENCY/Stage 4
- Risk assessment: new row for WARN-deferral fix (v20260325.8)

Closes governance gap from PR #65 (system-stability.md was not updated).

Related: #64, PR #65, PR #66