### PR TITLE
docs: sync WARN thresholds across all documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,7 +54,7 @@ vscode-extension/
 
 **ACCEL gate (critical)**: The `vscode_rss >= eff_warn` guard on the RSS velocity check is non-negotiable. Without it, V8 JIT compilation during startup legitimately spikes 300–900 MB/cycle at 1–2 GB total RSS, causing the watchdog to kill the Extension Host in a restart loop. Confirmed 2026-03-16: "Extension host terminated unexpectedly 3 times."
 
-**Startup mode**: 0.5s polling for 90s after new VS Code PIDs appear. Debounced at `STARTUP_DEBOUNCE=300s` — without this guard, language-server PID churn triggered startup mode 567 times in one day. Startup thresholds: `STARTUP_RSS_WARN_KB=2800000`, `STARTUP_RSS_EMERG_KB=3400000`.
+**Startup mode**: 0.5s polling for 90s after new VS Code PIDs appear. Debounced at `STARTUP_DEBOUNCE=300s` — without this guard, language-server PID churn triggered startup mode 567 times in one day. Startup thresholds: `STARTUP_RSS_WARN_KB=3200000`, `STARTUP_RSS_EMERG_KB=3400000`.
 
 **Action budget** (`utils.js`-equivalent in daemon): `action_budget_allows()` limits non-critical interventions to `ACTION_BUDGET_MAX=6` per `ACTION_BUDGET_WINDOW=30s`, and enforces at most one action per loop iteration (`_action_taken` flag). Prevents thrash storms under rapid-fire ACCEL or BURST triggers.
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This watchdog reads only `MemAvailable` and `MemTotal` — both correct on this 
 | `MemAvailable ≤ 15%`   | `SIGKILL` Chrome / Playwright                                                                    |
 | `MemAvailable ≤ 25%`   | `SIGTERM` Chrome / Playwright                                                                    |
 | PSI `full avg10 > 25%` | `SIGTERM` Chrome (sustained memory stall)                                                        |
-| VS Code RSS > 2.2 GB   | `SIGTERM` Chrome + desktop notification                                                          |
+| VS Code RSS > 3.0 GB   | `SIGTERM` Chrome + desktop notification; if no Chrome → log and defer to EMERGENCY               |
 | VS Code RSS > 3.2 GB   | `SIGKILL` Chrome; if no Chrome → `SIGTERM` highest-RSS extension host to save the VS Code window |
 | RSS velocity spike     | Kill lowest-value VS Code helper — **never** a language server or Extension Host at normal severity |
 | Every loop             | Set `oom_score_adj=0` on VS Code PIDs (counters Electron's 200–300 default)                      |
@@ -135,7 +135,7 @@ crostini-mem-watchdog/
 | `INTERVAL`            | `2`       | Seconds between normal checks                          |
 | `STARTUP_INTERVAL`    | `0.5`     | Seconds between checks in startup mode                 |
 | `STARTUP_DURATION`    | `90`      | Seconds to stay in startup mode after new VS Code PIDs |
-| `VSCODE_RSS_WARN_KB`  | `2200000` | ~2.2 GB — VS Code RSS warning level                    |
+| `VSCODE_RSS_WARN_KB`  | `3000000` | ~3.0 GB — VS Code RSS warning level                    |
 | `VSCODE_RSS_EMERG_KB` | `3200000` | ~3.2 GB — VS Code RSS emergency level                  |
 | `NOTIFY_INTERVAL`     | `300`     | Seconds between desktop notifications per severity     |
 
@@ -144,7 +144,7 @@ crostini-mem-watchdog/
 | Total RAM        | `VSCODE_RSS_WARN_KB` | `VSCODE_RSS_EMERG_KB` |
 | ---------------- | -------------------- | --------------------- |
 | 4 GB             | `1500000`            | `2000000`             |
-| 6 GB _(default)_ | `2200000`            | `3200000`             |
+| 6 GB _(default)_ | `3000000`            | `3200000`             |
 | 8 GB             | `3500000`            | `5000000`             |
 | 16 GB            | `6000000`            | `10000000`            |
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -15,13 +15,13 @@ The daemon acts on these conditions (checked every 2 seconds):
 | `MemAvailable ≤ 15%` (~945 MB on 6 GB) | `SIGKILL` Chrome / Playwright |
 | `MemAvailable ≤ 25%` (~1.6 GB on 6 GB) | `SIGTERM` Chrome / Playwright |
 | PSI `full avg10 > 25%` | `SIGTERM` Chrome (sustained memory stall) |
-| VS Code RSS > 2.5 GB | `SIGTERM` Chrome + desktop notification |
+| VS Code RSS > 3.0 GB | `SIGTERM` Chrome + desktop notification; if no Chrome → log and defer to EMERGENCY |
 | VS Code RSS > 3.5 GB | `SIGKILL` Chrome; if no Chrome → `SIGTERM` the highest-RSS extension host process to save the VS Code window |
 | RSS velocity spike | Kill lowest-value VS Code helper — **never** a language server or Extension Host at normal severity |
 
 **Language-server protection:** Built-in language servers (HTML, JSON, CSS, Markdown, ESLint) and the Extension Host process (hosting Copilot, Playwright MCP, and all extensions) are excluded from the helper-kill candidate pool at normal severity. These small processes (80–120 MB) are subject to VS Code's 5-crash-in-3-minutes permanent death threshold — killing one saves negligible memory while permanently disabling language intelligence or all extensions. They are only considered as last-resort targets at true emergency severity (RSS ≥ 3.5 GB).
 
-**Startup mode:** when new VS Code PIDs appear, the daemon switches to **0.5 s polling for 90 s** and drops the RSS emergency threshold to 2.0 GB — catching the extension-host spike that caused the crash this tool was built to prevent (0 → 4 GB RSS in under 2 seconds during startup).
+**Startup mode:** when new VS Code PIDs appear, the daemon switches to **0.5 s polling for 90 s** and drops the RSS emergency threshold to 3.4 GB — catching the extension-host spike that caused the crash this tool was built to prevent (0 → 4 GB RSS in under 2 seconds during startup).
 
 ---
 
@@ -62,7 +62,7 @@ Configure all thresholds via **VS Code Settings → Mem Watchdog**. Changes take
 | `sigtermThresholdPct` | `25` | `SIGTERM` Chrome when `MemAvailable` falls below this % of total RAM |
 | `sigkillThresholdPct` | `15` | Escalate to `SIGKILL` below this % |
 | `psiThresholdPct` | `25` | `SIGTERM` on PSI `full avg10` above this % |
-| `vscodeRssWarnMB` | `2500` | Warn + `SIGTERM` Chrome when total VS Code RSS exceeds this many MB |
+| `vscodeRssWarnMB` | `3000` | Warn + `SIGTERM` Chrome when total VS Code RSS exceeds this many MB |
 | `vscodeRssEmergencyMB` | `3500` | `SIGKILL` Chrome (or `SIGTERM` extension host) above this MB |
 
 > All settings use `scope: "machine"` — they do **not** sync across machines via Settings Sync. A threshold tuned for 6 GB RAM would be dangerously wrong on a 16 GB machine.
@@ -74,7 +74,7 @@ Configure all thresholds via **VS Code Settings → Mem Watchdog**. Changes take
 | System RAM | `vscodeRssWarnMB` | `vscodeRssEmergencyMB` |
 |---|---|---|
 | 4 GB | `1500` | `2000` |
-| 6 GB *(default)* | `2500` | `3500` |
+| 6 GB *(default)* | `3000` | `3500` |
 | 8 GB | `3500` | `5000` |
 | 16 GB | `6000` | `10000` |
 


### PR DESCRIPTION
**Post-release docs drift remediation** for v0.3.7.

7 stale threshold values identified by docs-drift-maintenance audit:

| File | Change |
|---|---|
| `README.md` | WARN 2.2→3.0 GB (3 values) |
| `vscode-extension/README.md` | WARN 2.5→3.0 GB (3 values) + startup emerg 2.0→3.4 GB |
| `.github/copilot-instructions.md` | `STARTUP_RSS_WARN_KB` 2800000→3200000 |

All drift was introduced by #64 (v20260325.8) threshold raises. The code, CHANGELOG, system-stability.md, and learnings.md were already updated — these are the remaining documentation surfaces.