### PR TITLE
feat(testing): add cgroup v2-native path for pressure tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@
 mem-watchdog.sh          ← core daemon; single infinite loop, no deps beyond coreutils
 mem-watchdog.service     ← systemd user unit (systemctl --user, NOT system)
 install.sh               ← shell-only installer (no VS Code required)
-test-watchdog.sh         ← 16-test suite; exits 0/1; logs to scratch/
+test-watchdog.sh         ← 17-test suite; exits 0/1; logs to scratch/
 vscode-extension/
   extension.js           ← activate(): install → config → commands → status bar (2s poll) → update check
   installer.js           ← SHA-256 hash-based daemon auto-install/upgrade + MIN_SAFE guard
@@ -70,7 +70,7 @@ EXPLORE → PLAN → IMPLEMENT → GATE → REFLECT → COMMIT
 **GATE**: All five checks must exit 0 — no exceptions, no skips:
 
 ```bash
-bash test-watchdog.sh                                                          # 16 bash tests, ~3s
+bash test-watchdog.sh                                                          # 17 bash tests, ~3s
 bash -n mem-watchdog.sh                                                        # syntax check
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh
 cd vscode-extension && npm test                                                # 75 JS unit tests, ~1s
@@ -91,7 +91,7 @@ npm run test:coverage      # + c8 V8 lcov output
 npm run test:stress        # pileup guard + event-loop lag + heap scenarios
 npx vsce package           # → mem-watchdog-status-x.y.z.vsix
 
-bash test-watchdog.sh      # 16 bash tests (repo root — REPO=$(dirname $0), not scripts/)
+bash test-watchdog.sh      # 17 bash tests (repo root — REPO=$(dirname $0), not scripts/)
 bash test-pressure.sh      # live memory allocation tests; needs RAM < 40% free
 ./mem-watchdog.sh --dry-run
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Installs](https://img.shields.io/visual-studio-marketplace/i/CurtisFranks.mem-watchdog-status?color=00d4aa)](https://marketplace.visualstudio.com/items?itemName=CurtisFranks.mem-watchdog-status)
 [![License: PolyForm NC](https://img.shields.io/badge/License-PolyForm%20NC%201.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-ChromeOS%20Crostini-4285f4)](https://chromeos.dev/en/linux)
-[![Tests](https://img.shields.io/badge/bash-16%2F16-brightgreen)](test-watchdog.sh)
+[![Tests](https://img.shields.io/badge/bash-17%2F17-brightgreen)](test-watchdog.sh)
 [![Tests](https://img.shields.io/badge/js-75%2F75-brightgreen)](vscode-extension/package.json)
 
 _`earlyoom` hard-crashes on Crostini (exit 104, every 3 seconds, zero protection). This replaces it with a VS Code-aware watchdog that kills Chrome before the kernel OOM-kills VS Code._
@@ -102,7 +102,7 @@ crostini-mem-watchdog/
 ├── mem-watchdog.sh              ← core daemon (bash, coreutils only)
 ├── mem-watchdog.service         ← systemd user service unit
 ├── install.sh                   ← shell-only installer (no VS Code required)
-├── test-watchdog.sh             ← 16-test validation suite
+├── test-watchdog.sh             ← 17-test validation suite
 ├── test-pressure.sh             ← live memory pressure tests
 ├── watchdog-tray.sh             ← optional: yad system tray icon
 └── vscode-extension/            ← VS Code extension (primary install path)
@@ -155,7 +155,7 @@ crostini-mem-watchdog/
 All 4 gates must pass before any change is published:
 
 ```bash
-bash test-watchdog.sh              # 16 bash tests (~3 s) — service, OOM scores, PSI, SwapFree safety, SIGTERM
+bash test-watchdog.sh              # 17 bash tests (~3 s) — service, OOM scores, PSI, SwapFree safety, SIGTERM
 cd vscode-extension && npm test    # 75 JS unit tests (~1 s) — extension state machine, activation singleton, pileup guard, utils
 bash -n mem-watchdog.sh            # bash syntax check
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh

--- a/test-pressure.sh
+++ b/test-pressure.sh
@@ -21,12 +21,14 @@
 #   - sudo -n must work without password (confirmed on this system)
 #   - python3 available (for controlled memory allocation)
 #
-# CGROUP NOTE (cgroup v1 — see docs/technical/system-stability.md §10):
-#   Writing to memory.limit_in_bytes constrains the kernel OOM hard limit
-#   but does NOT change /proc/meminfo values. So the watchdog's MemAvailable
-#   threshold logic is tested by ACTUAL allocation (Phase 2), while the cgroup
-#   limit acts as a safety net preventing runaway allocations from crashing
-#   the real VS Code session.
+# CGROUP NOTE (auto-detected — cgroup v1 or v2):
+#   On v1: writes to memory.limit_in_bytes as a hard safety ceiling.
+#   On v2: writes to memory.max as the equivalent hard limit.
+#   Both constrain the kernel OOM hard limit but do NOT change /proc/meminfo
+#   values. The watchdog's MemAvailable threshold logic is tested by ACTUAL
+#   allocation (Phase 2), while the cgroup limit acts as a safety net
+#   preventing runaway allocations from crashing the real VS Code session.
+#   See docs/technical/system-stability.md §10 for the cgroup v1 technique.
 #
 # Usage:
 #   bash test-pressure.sh              # full suite (requires ~1 GB headroom)
@@ -93,13 +95,65 @@ tee_log "Log: $LOG"
 $DRY_RUN && tee_log "${YEL}  *** DRY-RUN — no memory will be allocated, no processes killed ***${RST}"
 tee_log "════════════════════════════════════════════════════════════════"
 
-# ── Cgroup path discovery ─────────────────────────────────────────────────────
-CGRP=$(awk -F: '$2=="memory"{print "/sys/fs/cgroup/memory" $3; exit}' /proc/self/cgroup 2>/dev/null || echo "")
-if [[ -z "$CGRP" || ! -f "$CGRP/memory.limit_in_bytes" ]]; then
-  tee_log "${RED}ERROR: Cannot find memory cgroup at $CGRP${RST}"
+# ── Cgroup hierarchy detection (v1, v2, or hybrid) ──────────────────────────
+# Sets: CGROUP_MODE (v1|v2), CGRP (path), and per-mode file variables:
+#   _cg_limit_file   — hard limit (v1: memory.limit_in_bytes, v2: memory.max)
+#   _cg_usage_file   — current usage (v1: memory.usage_in_bytes, v2: memory.current)
+#   _cg_limit_unlimited — sentinel for "no limit" (v1: 9223372036854771712, v2: "max")
+CGROUP_MODE=""
+CGRP=""
+_cg_limit_file=""
+_cg_usage_file=""
+_cg_limit_unlimited=""
+
+detect_cgroup_mode() {
+  local v2_root="" v2_rel="" v2_path=""
+  local v1_rel="" v1_path=""
+
+  # ── Try cgroup v2 first (preferred on modern kernels) ─────────────────────
+  # cgroup2 mount point — typically /sys/fs/cgroup on unified systems
+  v2_root=$(mount -t cgroup2 2>/dev/null | awk '{print $3; exit}')
+  if [[ -n "$v2_root" ]]; then
+    # Unified hierarchy: line 0 has empty controller field → "0::/<path>"
+    v2_rel=$(awk -F: '$1=="0" && $2==""{print $3; exit}' /proc/self/cgroup 2>/dev/null)
+    v2_path="${v2_root}${v2_rel}"
+    if [[ -f "${v2_path}/memory.max" ]]; then
+      CGROUP_MODE="v2"
+      CGRP="$v2_path"
+      _cg_limit_file="${v2_path}/memory.max"
+      _cg_usage_file="${v2_path}/memory.current"
+      _cg_limit_unlimited="max"
+      return 0
+    fi
+  fi
+
+  # ── Fall back to cgroup v1 ────────────────────────────────────────────────
+  v1_rel=$(awk -F: '$2=="memory"{print $3; exit}' /proc/self/cgroup 2>/dev/null)
+  if [[ -n "$v1_rel" ]]; then
+    v1_path="/sys/fs/cgroup/memory${v1_rel}"
+    if [[ -f "${v1_path}/memory.limit_in_bytes" ]]; then
+      CGROUP_MODE="v1"
+      CGRP="$v1_path"
+      _cg_limit_file="${v1_path}/memory.limit_in_bytes"
+      _cg_usage_file="${v1_path}/memory.usage_in_bytes"
+      _cg_limit_unlimited="9223372036854771712"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+if ! detect_cgroup_mode; then
+  tee_log "${RED}ERROR: Cannot find memory cgroup (neither v1 nor v2 detected)${RST}"
+  tee_log "  v1 check: /proc/self/cgroup memory controller → ${v1_rel:-none}"
+  tee_log "  v2 check: mount -t cgroup2 → ${v2_root:-none}"
   exit 1
 fi
-tee_log "  Cgroup: $CGRP"
+tee_log "  Cgroup mode: ${CGROUP_MODE}"
+tee_log "  Cgroup path: ${CGRP}"
+tee_log "  Limit file:  ${_cg_limit_file}"
+tee_log "  Usage file:  ${_cg_usage_file}"
 
 # ── SAFETY PREFLIGHT ─────────────────────────────────────────────────────────
 tee_log ""
@@ -145,25 +199,57 @@ tee_log "  ✓ ${avail_pct}% RAM free (${avail_kb} kB) — sufficient headroom"
 tee_log ""
 tee_log "── Installing cgroup safety ceiling"
 
-ORIG_LIMIT=$(cat "$CGRP/memory.limit_in_bytes")
+ORIG_LIMIT=$(cat "$_cg_limit_file")
 # Safety ceiling = 90% of total RAM.
 # This keeps the hard cgroup OOM wall above VS Code's footprint (~2.5 GB) but
 # still prevents runaway allocations from consuming the last 10% (~630 MB).
 # The watchdog's 25% SIGTERM threshold fires at 75% utilization — well before the ceiling.
 safety_ceiling_bytes=$(( total_kb * 90 * 1024 / 100 ))
 
+# ── cgroup write helpers (abstract v1/v2 differences) ─────────────────────────
+# v1: limit is in bytes, unlimited sentinel is a large integer
+# v2: memory.max is in bytes or the literal string "max" for unlimited
+cgroup_write_limit() {
+  local value="$1"
+  if [[ "$CGROUP_MODE" == "v2" ]]; then
+    echo "$value" | sudo -n tee "$_cg_limit_file" > /dev/null 2>&1
+  else
+    echo "$value" | sudo -n tee "$_cg_limit_file" > /dev/null 2>&1
+  fi
+}
+
+cgroup_read_usage_mb() {
+  local val
+  read -r val < "$_cg_usage_file" 2>/dev/null || val=0
+  echo $(( val / 1024 / 1024 ))
+}
+
+cgroup_read_limit_mb() {
+  local val
+  read -r val < "$_cg_limit_file" 2>/dev/null || val=0
+  if [[ "$val" == "max" || "$val" == "$_cg_limit_unlimited" ]]; then
+    echo "unlimited"
+  else
+    echo $(( val / 1024 / 1024 ))
+  fi
+}
+
 cleanup_cgroup() {
   tee_log ""
-  tee_log "── Restoring cgroup limit to original (${ORIG_LIMIT} bytes)"
-  sudo -n sh -c "echo ${ORIG_LIMIT} > '${CGRP}/memory.limit_in_bytes'" 2>/dev/null || true
+  tee_log "── Restoring cgroup limit to original (${ORIG_LIMIT})"
+  cgroup_write_limit "$ORIG_LIMIT" || true
 }
 trap cleanup_cgroup EXIT INT TERM
 
 if $DRY_RUN; then
-  tee_log "  (dry-run: would set ceiling to $((safety_ceiling_bytes / 1024 / 1024)) MB)"
+  tee_log "  (dry-run: would set ceiling to $((safety_ceiling_bytes / 1024 / 1024)) MB via ${_cg_limit_file})"
 else
-  sudo -n sh -c "echo ${safety_ceiling_bytes} > '${CGRP}/memory.limit_in_bytes'"
-  tee_log "  ✓ Ceiling set: $((safety_ceiling_bytes / 1024 / 1024)) MB (90% of total RAM — watchdog fires at 75% utilization, well before this)"
+  if cgroup_write_limit "$safety_ceiling_bytes"; then
+    tee_log "  ✓ Ceiling set: $((safety_ceiling_bytes / 1024 / 1024)) MB via ${_cg_limit_file} (${CGROUP_MODE})"
+  else
+    tee_log "${RED}ERROR: Cannot write to ${_cg_limit_file} — sudo -n may not work${RST}"
+    exit 1
+  fi
 fi
 
 # ── Structured snapshot for post-analysis ─────────────────────────────────────────
@@ -251,17 +337,22 @@ snapshot() {
 
   # ── Cgroup accounting — direct procfs reads (zero fork) ──────────────────────
   cgrp_used_mb=0; cgrp_limit_mb=0
-  { read -r _sv < "$CGRP/memory.usage_in_bytes"  2>/dev/null && cgrp_used_mb=$(( _sv / 1024 / 1024 ));  } || true
-  { read -r _sv < "$CGRP/memory.limit_in_bytes"  2>/dev/null && cgrp_limit_mb=$(( _sv / 1024 / 1024 )); } || true
+  { read -r _sv < "$_cg_usage_file" 2>/dev/null && cgrp_used_mb=$(( _sv / 1024 / 1024 )); } || true
+  { read -r _sv < "$_cg_limit_file" 2>/dev/null; } || _sv=0
+  if [[ "$_sv" == "max" || "$_sv" == "$_cg_limit_unlimited" ]]; then
+    cgrp_limit_mb=0  # sentinel: unlimited
+  else
+    cgrp_limit_mb=$(( _sv / 1024 / 1024 ))
+  fi
 
   # ── Human-readable log line (printf is a bash builtin — zero fork) ───────────
   tee_log "  [snap:${label}] ts=${ts} | avail=${avail_pct}%/${avail_kb}kB | free=${free_kb}kB | dirty=${dirty_kb}kB | psi_full=${psi_full} psi_some=${psi_some} | vscode=${vscode_rss}kB/${vscode_npids}pids | wd_rss=${wd_rss}kB wd_cputicks=${wd_cpu_ticks} | cgroup=${cgrp_used_mb}MB/${cgrp_limit_mb}MB"
 
   # ── JSON line for jq / pandas post-analysis (printf builtin — zero fork) ─────
-  printf '{"label":"%s","ts":%s,"avail_pct":%d,"avail_kb":%d,"free_kb":%d,"dirty_kb":%d,"psi_full":"%s","psi_some":"%s","vscode_rss_kb":%d,"vscode_npids":%d,"wd_rss_kb":%d,"wd_cpu_ticks":%d,"cgroup_used_mb":%d,"cgroup_limit_mb":%d}\n' \
+  printf '{"label":"%s","ts":%s,"avail_pct":%d,"avail_kb":%d,"free_kb":%d,"dirty_kb":%d,"psi_full":"%s","psi_some":"%s","vscode_rss_kb":%d,"vscode_npids":%d,"wd_rss_kb":%d,"wd_cpu_ticks":%d,"cgroup_mode":"%s","cgroup_used_mb":%d,"cgroup_limit_mb":%d}\n' \
     "$label" "$ts" "$avail_pct" "$avail_kb" "$free_kb" "$dirty_kb" \
     "$psi_full" "$psi_some" "$vscode_rss" "$vscode_npids" \
-    "$wd_rss" "$wd_cpu_ticks" "$cgrp_used_mb" "$cgrp_limit_mb" >> "$SNAP_JSON"
+    "$wd_rss" "$wd_cpu_ticks" "$CGROUP_MODE" "$cgrp_used_mb" "$cgrp_limit_mb" >> "$SNAP_JSON"
 }
 
 # ── TEST 1: SIGTERM threshold (MemAvailable ≤ 25%) ─────────────────────────────────

--- a/test-watchdog.sh
+++ b/test-watchdog.sh
@@ -281,6 +281,52 @@ else
   FAIL "Tier classification incomplete"
 fi
 
+# ── TEST 17: test-pressure.sh cgroup mode detection ─────────────────────────
+tee_log ""
+tee_log "── Test 17: test-pressure.sh cgroup hierarchy detection"
+
+# Source just the detect_cgroup_mode function from test-pressure.sh
+# by extracting the function definition and calling it in a subshell.
+cg_test_ok=true
+
+# Verify the function exists in test-pressure.sh
+if ! grep -q 'detect_cgroup_mode()' "$REPO/test-pressure.sh"; then
+  tee_log "    Missing detect_cgroup_mode() function in test-pressure.sh"
+  cg_test_ok=false
+fi
+
+# Verify both v1 and v2 code paths exist
+if ! grep -q 'memory\.max' "$REPO/test-pressure.sh"; then
+  tee_log "    Missing cgroup v2 memory.max reference"
+  cg_test_ok=false
+fi
+if ! grep -q 'memory\.limit_in_bytes' "$REPO/test-pressure.sh"; then
+  tee_log "    Missing cgroup v1 memory.limit_in_bytes reference"
+  cg_test_ok=false
+fi
+
+# Verify mode banner is emitted
+if ! grep -q 'Cgroup mode:' "$REPO/test-pressure.sh"; then
+  tee_log "    Missing cgroup mode banner output"
+  cg_test_ok=false
+fi
+
+# Live detection: run --dry-run and verify a mode is reported
+dry_output=$(bash "$REPO/test-pressure.sh" --dry-run 2>&1 || true)
+if echo "$dry_output" | grep -qE 'Cgroup mode: (v1|v2)'; then
+  detected_mode=$(echo "$dry_output" | grep 'Cgroup mode:' | awk '{print $NF}')
+  tee_log "    Live detection: ${detected_mode}"
+else
+  tee_log "    --dry-run did not report a cgroup mode"
+  cg_test_ok=false
+fi
+
+if $cg_test_ok; then
+  PASS "test-pressure.sh has cgroup v1/v2 detection with mode banner (detected: ${detected_mode:-unknown})"
+else
+  FAIL "Cgroup detection incomplete in test-pressure.sh"
+fi
+
 # ── SUMMARY ──────────────────────────────────────────────────────────────────
 tee_log ""
 tee_log "════════════════════════════════════════════════════════════════"


### PR DESCRIPTION
## Summary

Replaces hardcoded cgroup v1 paths in `test-pressure.sh` with a `detect_cgroup_mode()` function that probes for v2 first (`memory.max`, `memory.current`) then falls back to v1 (`memory.limit_in_bytes`, `memory.usage_in_bytes`). All cgroup operations go through abstracted helpers.

## Changes

- **`test-pressure.sh`**: New `detect_cgroup_mode()` function with v2-first detection, abstracted helpers (`cgroup_write_limit()`, `cgroup_read_usage_mb()`, `cgroup_read_limit_mb()`), mode banner, JSON output includes `cgroup_mode` field
- **`test-watchdog.sh`**: Test 17 validates detection function, dual code paths, mode banner, live `--dry-run` detection
- **`README.md`** + **`.github/copilot-instructions.md`**: 16→17 bash test count references

## Gate evidence

- `bash test-watchdog.sh`: 17/17 pass
- `bash -n mem-watchdog.sh`: clean
- `shellcheck`: clean
- `npm test`: 75/75 pass
- `docs-integrity-check.sh`: 4/4 pass

Closes #23