### PR TITLE
docs(daemon): post-merge governance for #74 WARN dead zone fix

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,7 +56,7 @@ vscode-extension/
 
 **Startup mode**: 0.5s polling for 90s after new VS Code PIDs appear. Debounced at `STARTUP_DEBOUNCE=300s` — without this guard, language-server PID churn triggered startup mode 567 times in one day. Startup thresholds: `STARTUP_RSS_WARN_KB=3200000`, `STARTUP_RSS_EMERG_KB=3400000`.
 
-**Action budget** (`utils.js`-equivalent in daemon): `action_budget_allows()` limits non-critical interventions to `ACTION_BUDGET_MAX=6` per `ACTION_BUDGET_WINDOW=30s`, and enforces at most one action per loop iteration (`_action_taken` flag). Prevents thrash storms under rapid-fire ACCEL or BURST triggers.
+**Action budget** (`utils.js`-equivalent in daemon): `action_budget_allows()` limits non-critical interventions to `ACTION_BUDGET_MAX=6` per `ACTION_BUDGET_WINDOW=30s`, and enforces at most one action per loop iteration (`_action_taken` flag). Prevents thrash storms under rapid-fire ACCEL or BURST triggers. **EMERGENCY resets `_action_taken=false`** before processing — non-critical kills (e.g., ACCEL tsserver) cannot block emergency response. When `kill_top_vscode_helper` finds no candidate at WARN with no Chrome, triggers `cgroup_throttle()` + `cgroup_reclaim()` as non-destructive fallback.
 
 **`kill_vscode_main()`**: SIGTERM on the VS Code main process (identified by `/usr/share/code/code$` cmdline). Used as circuit-breaker only — gated by `CODE_RECOVERY_COOLDOWN=30s`. Causes VS Code window restart, which is preferable to kernel OOM-kill.
 

--- a/docs/technical/system-stability.md
+++ b/docs/technical/system-stability.md
@@ -173,6 +173,8 @@ Setting this to **512 MB** (the original value) was counterproductive:
 | 2026-03-25 post-#55 | 0 | Daemon v20260325.5: Extension Host identified by `--type=utility` + `--inspect-port`; other utility processes now eligible kill candidates; `helper_no_candidate=0` |
 | 2026-03-26 00:00:18 | 2 | WARN→ExtHost escalation: `kill_extension_host()` fired at 2.7 GB RSS / 76% free memory. WARN threshold (2.2–2.56 GB) was below normal baseline (2.3–2.7 GB), so WARN fired constantly. `kill_top_vscode_helper` found no candidate (utility processes correctly excluded), fell through to `kill_extension_host()` — destroyed terminal, Copilot, all extensions. ExtHost restart triggered extension v0.3.1 installer → overwrote daemon v20260325.7 with v20260313.2 (12 days old) → old daemon BURST-killed tsserver at 75% free. (issue #64, daemon v20260325.8) |
 | 2026-03-26 post-#64 | 0 | Daemon v20260325.8: WARN and Stage 3 no longer escalate to `kill_extension_host()` — log and defer to EMERGENCY/Stage 4. `VSCODE_RSS_WARN_KB` raised 2.2→3.0 GB. `STARTUP_RSS_WARN_KB` raised 2.8→3.2 GB. Utility processes excluded at non-emergency in all 3 awk blocks. |
+| 2026-03-26 12:15:03 | 1 | WARN dead zone: 18 consecutive WARN polls (3.0–3.1 GB, 74% free, no Chrome) with `helper_no_candidate=301`. No cgroup throttle/reclaim triggered at WARN. ACCEL killed tsserver (104 MB of 3.6 GB — 3%) and consumed action budget, blocking EMERGENCY on same iteration. Next cycle: EMERGENCY at 3.77 GB → `kill_vscode_main`. (issue #74, daemon v20260326.3) |
+| 2026-03-26 post-#74 | 0 | Daemon v20260326.3: WARN fallback triggers `cgroup_throttle()` + `cgroup_reclaim()` when no kill candidate exists. EMERGENCY resets `_action_taken=false` — non-critical kills cannot block emergency. No-candidate log suppressed after first occurrence. |
 
 ### The 2026-03-05 crash — what was fixed
 
@@ -195,6 +197,7 @@ Three root causes:
 | Action-budget no-op fix (v20260325.1) | Pathway #1 — no-op `kill_browsers()` no longer exhausts budget; fallback kills always reachable | ✅ Fixed |
 | Utility-process detection fix (v20260325.5) | Pathway #1 — Extension Host identified by `--inspect-port`; non-ExtHost utility processes eligible as kill candidates; `kill_extension_host()` finds modern Extension Host | ✅ Fixed |
 | WARN-deferral fix (v20260325.8) | Pathway #1 — WARN and Stage 3 no longer escalate to `kill_extension_host()`; defer to EMERGENCY/Stage 4. WARN threshold raised to 3.0 GB (above steady-state baseline). Prevents watchdog from destroying its own editing session at non-emergency RSS. | ✅ Fixed |
+| WARN cgroup fallback (v20260326.3) | Pathway #1 — when no kill candidate exists at WARN, triggers `cgroup_throttle()` + `cgroup_reclaim()` as non-destructive intermediate relief. EMERGENCY resets `_action_taken` so non-critical kills cannot block it. | ✅ Fixed |
 | Container swap | Pathway #1 — direct relief for container kernel OOM | ❌ Blocked (CapEff=0, see §4) |
 
 **Residual risk:** The container kernel can still OOM if VS Code + idle MCP browser + a Playwright session all run simultaneously without the MCP browser being killed first. The watchdog mitigates this but cannot guarantee prevention if the spike is faster than the 2s polling interval.

--- a/docs/workflow/learnings.md
+++ b/docs/workflow/learnings.md
@@ -20,6 +20,30 @@
 
 ---
 
+### 2026-03-26 — WARN dead zone: no cgroup fallback when no kill candidate exists
+
+**Context**: VS Code crashed at 12:15:03 during process priority research. Journal showed 18 consecutive WARN polls (3.0–3.1 GB RSS, 74% free, no Chrome) with `helper_no_candidate=301`. No cgroup throttle or reclaim was triggered at WARN level.
+
+**Discovery**: Three independent bugs created a WARN-level dead zone where the daemon watched RSS climb from 3.0→3.77 GB with zero intervention capability:
+
+1. **No non-destructive WARN fallback**: When `kill_top_vscode_helper("normal")` found no candidate (all utility processes excluded at WARN, all language servers protected, ExtHost excluded) and no Chrome was running, the daemon logged "deferring to EMERGENCY" and did nothing. The cgroup throttle (`soft_limit`) and reclaim (`force_empty`) mechanisms — available since PR #71 — were never triggered at WARN level. RSS grew unchecked from 3.0 GB to 3.6 GB over ~36 seconds.
+
+2. **ACCEL tsserver kill consumed action gate, blocking EMERGENCY**: At 3.6 GB, ACCEL detected +350 MB/cycle and killed tsserver (104 MB of 3.6 GB total — 3% freed). This set `_action_taken=true`. EMERGENCY at 3.61 GB on the same loop iteration was blocked by the action gate. Only on the *next* 0.5s cycle (RSS now 3.77 GB) did `kill_vscode_main` fire.
+
+3. **301 identical log lines**: `kill_top_vscode_helper` logged "No VS Code helper candidate found" on every poll — 301 times in 36 seconds — flooding the journal with identical no-op messages that obscured the crash sequence during diagnosis.
+
+**Fixes applied (v20260326.3)**:
+- WARN fallback now triggers `cgroup_throttle()` + `cgroup_reclaim()` when `kill_top_vscode_helper` finds no candidate and no Chrome is running. This provides non-destructive intermediate pressure relief without killing any process.
+- EMERGENCY resets `_action_taken=false` before processing. Non-critical kills (e.g., ACCEL tsserver) can no longer block emergency response.
+- First no-candidate message logs with "(subsequent identical results suppressed)"; subsequent occurrences counted silently; summary logged when a candidate is finally found.
+
+**Application**:
+- When a severity level has "no safe target to kill," the correct response is non-destructive intervention (cgroup throttle/reclaim), not "do nothing and wait." Doing nothing allows RSS to grow unchecked through the entire WARN→EMERGENCY gap.
+- EMERGENCY must always be reachable regardless of what happened earlier in the same loop iteration. The action gate was designed to prevent thrash storms, not to block last-resort emergency response.
+- Repetitive no-op log lines should be suppressed after the first occurrence. The journal should capture the *pattern* (first occurrence + count), not every individual instance.
+
+---
+
 ### 2026-03-26 — WARN→ExtHost escalation killed terminal and Copilot at 76% free memory
 
 **Context**: Agent lost terminal access 3 times during a single session. Each time, VS Code showed "shared background process terminated unexpectedly." Journal investigation revealed the watchdog killed the Extension Host at WARN level (2.7 GB RSS, 76% free memory).


### PR DESCRIPTION
Post-merge documentation updates for PR #75 (Closes #74):

- **system-stability.md §8**: crash entry for 2026-03-26 12:15:03 + post-fix row
- **system-stability.md §9**: WARN cgroup fallback mitigation row in risk assessment
- **learnings.md**: new entry documenting three-bug WARN dead zone discovery
- **copilot-instructions.md**: document EMERGENCY `_action_taken` reset and WARN cgroup throttle/reclaim fallback