### PR TITLE
fix(daemon): raise RSS thresholds for Copilot Chat multi-agent workloads

### DIFF
--- a/mem-watchdog.sh
+++ b/mem-watchdog.sh
@@ -67,7 +67,7 @@ STAGE4_MEM_PCT=15              # OR MemAvailable < 15%
 # configWriter.js (v0.3.x) writes these to ~/.config/mem-watchdog/config.sh.
 # After config sourcing below, they are mapped to stage constants.
 INTERVAL=2             # Seconds between checks (was 4 — confirmed too slow in crash of 2026-03-05)
-export WATCHDOG_VERSION=20260326.3   # 2026-03-26 v3: + WARN cgroup throttle fallback, EMERGENCY bypasses action gate, log suppression (#74)
+export WATCHDOG_VERSION=20260326.4   # 2026-03-26 v4: raise RSS thresholds for Copilot Chat multi-agent workloads (#77)
 OOM_VSCODE_ADJ=0       # oom_score_adj for VS Code: lowers Electron's default 200-300
 OOM_CHROME_ADJ=1000    # oom_score_adj for Chrome: maximum killable
 
@@ -98,8 +98,8 @@ TIER_DISPOSABLE_PATTERN_AUX='node.*playwright'     # pgrep -f ERE for disposable
 
 # VS Code RSS thresholds (confirmed: extension host hit 4 GB, watchdog had no Chrome to kill)
 # Lower thresholds so we can intervene BEFORE the kernel OOM fires.
-VSCODE_RSS_EMERG_KB=3200000   # ~3.2 GB — emergency cutoff before kernel OOM territory
-VSCODE_RSS_WARN_KB=3000000    # ~3.0 GB — SIGTERM Chrome; system baseline is 2.3–2.7 GB
+VSCODE_RSS_EMERG_KB=3800000   # ~3.8 GB — emergency cutoff; Copilot Chat peaks at 3.0–3.5 GB (#77)
+VSCODE_RSS_WARN_KB=3400000    # ~3.4 GB — SIGTERM Chrome; Copilot Chat baseline 3.0–3.5 GB (#77)
 NOTIFY_INTERVAL=300           # seconds between desktop notifications per severity
 
 # ── Startup mode — faster polling + tighter thresholds for 90s after VS Code starts ──
@@ -107,8 +107,8 @@ NOTIFY_INTERVAL=300           # seconds between desktop notifications per severi
 # Fix: detect new VS Code PIDs, switch to 0.5s interval, drop emergency threshold to 2 GB.
 STARTUP_INTERVAL=0.5          # seconds between checks during VS Code startup
 STARTUP_DURATION=90           # seconds to stay in startup mode after new VS Code PIDs
-STARTUP_RSS_WARN_KB=3200000   # ~3.2 GB — startup can spike fast; must be ≥ VSCODE_RSS_WARN_KB
-STARTUP_RSS_EMERG_KB=3400000  # ~3.4 GB — emergency ceiling in startup mode
+STARTUP_RSS_WARN_KB=3600000   # ~3.6 GB — startup can spike fast; must be ≥ VSCODE_RSS_WARN_KB (#77)
+STARTUP_RSS_EMERG_KB=4000000  # ~4.0 GB — emergency ceiling in startup mode (#77)
 STARTUP_DEBOUNCE=300          # minimum seconds between startup mode activations
                               # VS Code language servers (TS, ESLint, GitLens workers) spawn
                               # new code PIDs throughout normal development. Without this guard

--- a/vscode-extension/configWriter.js
+++ b/vscode-extension/configWriter.js
@@ -59,10 +59,10 @@ function writeConfig(cfg) {
     if (warnMB >= emergMB) {
         warnings.push(
             `vscodeRssWarnMB (${warnMB} MB) must be < vscodeRssEmergencyMB (${emergMB} MB). ` +
-            `Reverting both to defaults (warn=2500, emerg=3500).`
+            `Reverting both to defaults (warn=3400, emerg=3800).`
         );
-        warnMB = 2500;
-        emergMB = 3500;
+        warnMB = 3400;
+        emergMB = 3800;
     }
 
     for (const w of warnings) {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -115,21 +115,21 @@
         },
         "memWatchdog.vscodeRssWarnMB": {
           "type": "number",
-          "default": 3000,
+          "default": 3400,
           "minimum": 500,
           "maximum": 8000,
           "scope": "machine",
           "order": 4,
-          "markdownDescription": "Warn + `SIGTERM` Chrome when total VS Code RSS exceeds this many MB. Default: `3000` (3.0 GB). Normal baseline on Crostini is 2.3–2.7 GB — set above your steady state."
+          "markdownDescription": "Warn + `SIGTERM` Chrome when total VS Code RSS exceeds this many MB. Default: `3400` (3.4 GB). Copilot Chat multi-agent peaks at 3.0–3.5 GB — set above your steady state."
         },
         "memWatchdog.vscodeRssEmergencyMB": {
           "type": "number",
-          "default": 3500,
+          "default": 3800,
           "minimum": 1000,
           "maximum": 8000,
           "scope": "machine",
           "order": 5,
-          "markdownDescription": "Emergency: `SIGKILL` Chrome (or `SIGTERM` highest-RSS ext host if no Chrome) when VS Code RSS exceeds this many MB. Default: `3500` (3.5 GB)."
+          "markdownDescription": "Emergency: `SIGKILL` Chrome (or `SIGTERM` highest-RSS ext host if no Chrome) when VS Code RSS exceeds this many MB. Default: `3800` (3.8 GB)."
         }
       }
     }

--- a/vscode-extension/test/unit/configWriter.test.js
+++ b/vscode-extension/test/unit/configWriter.test.js
@@ -21,8 +21,8 @@ const DEFAULTS = {
     sigtermThresholdPct:   25,
     sigkillThresholdPct:   15,
     psiThresholdPct:       25,
-    vscodeRssWarnMB:     2500,
-    vscodeRssEmergencyMB: 3500,
+    vscodeRssWarnMB:     3400,
+    vscodeRssEmergencyMB: 3800,
 };
 
 function makeCfg(overrides = {}) {
@@ -99,13 +99,13 @@ describe('writeConfig — RSS threshold cross-field validation', () => {
         assert.equal(warnings.length, 1);
     });
 
-    test('warnMB > emergMB: written values are safe defaults (2500/3500 MB → KB)', (t) => {
+    test('warnMB > emergMB: written values are safe defaults (3400/3800 MB → KB)', (t) => {
         const out = captureWrite(t);
         writeConfig(makeCfg({ vscodeRssWarnMB: 4000, vscodeRssEmergencyMB: 3000 }));
 
         const content = out.get();
-        assert.ok(content.includes(`VSCODE_RSS_WARN_KB=${2500 * 1024}`),  'warn reverted to 2500 MB');
-        assert.ok(content.includes(`VSCODE_RSS_EMERG_KB=${3500 * 1024}`), 'emerg reverted to 3500 MB');
+        assert.ok(content.includes(`VSCODE_RSS_WARN_KB=${3400 * 1024}`),  'warn reverted to 3400 MB');
+        assert.ok(content.includes(`VSCODE_RSS_EMERG_KB=${3800 * 1024}`), 'emerg reverted to 3800 MB');
     });
 });
 


### PR DESCRIPTION
## Summary

Copilot Chat multi-agent research legitimately drives VS Code RSS to 3.0–3.5 GB. Previous thresholds gave only 300 MB headroom above normal Copilot peaks, triggering `kill_vscode_main` during legitimate high-memory AI work (crash at 12:44:57, 2026-03-26).

## Changes

| Threshold | Old | New |
|---|---|---|
| `VSCODE_RSS_WARN_KB` | 3,000,000 (3.0 GB) | 3,400,000 (3.4 GB) |
| `VSCODE_RSS_EMERG_KB` | 3,200,000 (3.2 GB) | 3,800,000 (3.8 GB) |
| `STARTUP_RSS_WARN_KB` | 3,200,000 (3.2 GB) | 3,600,000 (3.6 GB) |
| `STARTUP_RSS_EMERG_KB` | 3,400,000 (3.4 GB) | 4,000,000 (4.0 GB) |

Also updates:
- Extension defaults (`package.json`)
- `configWriter.js` safe fallback values
- Test assertions

## Gate evidence

```
bash test-watchdog.sh:   18/18 passed
bash -n mem-watchdog.sh: OK
shellcheck:              clean
npm test:                75/75 passed
docs-integrity-check.sh: 4/4 passed
```

Closes #77