### PR TITLE
docs(daemon): post-merge governance for #77 threshold raise

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,14 +47,14 @@ vscode-extension/
 | `MemAvailable ≤ 15%` | `SIGKILL` Chrome/Playwright |
 | `MemAvailable ≤ 25%` | `SIGTERM` Chrome/Playwright |
 | PSI `full avg10 > 25%` | `SIGTERM` Chrome/Playwright |
-| VS Code RSS ≥ `VSCODE_RSS_EMERG_KB` (3.2 GB) | `SIGKILL` Chrome; if no Chrome → `kill_vscode_main()` |
-| VS Code RSS ≥ `VSCODE_RSS_WARN_KB` (3.0 GB) | `SIGTERM` Chrome + desktop alert; if no Chrome → `kill_top_vscode_helper()`; if no candidate → log and defer to EMERGENCY |
+| VS Code RSS ≥ `VSCODE_RSS_EMERG_KB` (3.8 GB) | `SIGKILL` Chrome; if no Chrome → `kill_vscode_main()` |
+| VS Code RSS ≥ `VSCODE_RSS_WARN_KB` (3.4 GB) | `SIGTERM` Chrome + desktop alert; if no Chrome → `kill_top_vscode_helper()`; if no candidate → log and defer to EMERGENCY |
 | RSS delta ≥ `RSS_ACCEL_KB` (300 MB/cycle) **AND** `vscode_rss ≥ eff_warn` | `kill_top_vscode_helper()` or `kill_browsers(TERM)` |
 | `RSS_RUNAWAY_STREAK=3` consecutive ACCEL cycles above `RSS_RUNAWAY_MIN_KB` (2.6 GB) | Circuit-breaker: `kill_vscode_main()` |
 
 **ACCEL gate (critical)**: The `vscode_rss >= eff_warn` guard on the RSS velocity check is non-negotiable. Without it, V8 JIT compilation during startup legitimately spikes 300–900 MB/cycle at 1–2 GB total RSS, causing the watchdog to kill the Extension Host in a restart loop. Confirmed 2026-03-16: "Extension host terminated unexpectedly 3 times."
 
-**Startup mode**: 0.5s polling for 90s after new VS Code PIDs appear. Debounced at `STARTUP_DEBOUNCE=300s` — without this guard, language-server PID churn triggered startup mode 567 times in one day. Startup thresholds: `STARTUP_RSS_WARN_KB=3200000`, `STARTUP_RSS_EMERG_KB=3400000`.
+**Startup mode**: 0.5s polling for 90s after new VS Code PIDs appear. Debounced at `STARTUP_DEBOUNCE=300s` — without this guard, language-server PID churn triggered startup mode 567 times in one day. Startup thresholds: `STARTUP_RSS_WARN_KB=3600000`, `STARTUP_RSS_EMERG_KB=4000000`.
 
 **Action budget** (`utils.js`-equivalent in daemon): `action_budget_allows()` limits non-critical interventions to `ACTION_BUDGET_MAX=6` per `ACTION_BUDGET_WINDOW=30s`, and enforces at most one action per loop iteration (`_action_taken` flag). Prevents thrash storms under rapid-fire ACCEL or BURST triggers. **EMERGENCY resets `_action_taken=false`** before processing — non-critical kills (e.g., ACCEL tsserver) cannot block emergency response. When `kill_top_vscode_helper` finds no candidate at WARN with no Chrome, triggers `cgroup_throttle()` + `cgroup_reclaim()` as non-destructive fallback.
 

--- a/docs/technical/system-stability.md
+++ b/docs/technical/system-stability.md
@@ -175,6 +175,8 @@ Setting this to **512 MB** (the original value) was counterproductive:
 | 2026-03-26 post-#64 | 0 | Daemon v20260325.8: WARN and Stage 3 no longer escalate to `kill_extension_host()` — log and defer to EMERGENCY/Stage 4. `VSCODE_RSS_WARN_KB` raised 2.2→3.0 GB. `STARTUP_RSS_WARN_KB` raised 2.8→3.2 GB. Utility processes excluded at non-emergency in all 3 awk blocks. |
 | 2026-03-26 12:15:03 | 1 | WARN dead zone: 18 consecutive WARN polls (3.0–3.1 GB, 74% free, no Chrome) with `helper_no_candidate=301`. No cgroup throttle/reclaim triggered at WARN. ACCEL killed tsserver (104 MB of 3.6 GB — 3%) and consumed action budget, blocking EMERGENCY on same iteration. Next cycle: EMERGENCY at 3.77 GB → `kill_vscode_main`. (issue #74, daemon v20260326.3) |
 | 2026-03-26 post-#74 | 0 | Daemon v20260326.3: WARN fallback triggers `cgroup_throttle()` + `cgroup_reclaim()` when no kill candidate exists. EMERGENCY resets `_action_taken=false` — non-critical kills cannot block emergency. No-candidate log suppressed after first occurrence. |
+| 2026-03-26 12:44:57 | 1 | Thresholds too low for Copilot Chat multi-agent workloads. RSS grew 2,328→3,114→3,300→3,423 MB in 47s during legitimate research. No Chrome, no helper candidate. STARTUP_RSS_EMERG_KB=3,400,000 gave only 300 MB above Copilot peak → `kill_vscode_main`. No kernel OOM (dmesg clean). (issue #77, daemon v20260326.4) |
+| 2026-03-26 post-#77 | 0 | Daemon v20260326.4: WARN 3.0→3.4 GB, EMERG 3.2→3.8 GB, STARTUP_WARN 3.2→3.6 GB, STARTUP_EMERG 3.4→4.0 GB. Extension defaults and configWriter fallbacks updated to match. |
 
 ### The 2026-03-05 crash — what was fixed
 
@@ -198,6 +200,7 @@ Three root causes:
 | Utility-process detection fix (v20260325.5) | Pathway #1 — Extension Host identified by `--inspect-port`; non-ExtHost utility processes eligible as kill candidates; `kill_extension_host()` finds modern Extension Host | ✅ Fixed |
 | WARN-deferral fix (v20260325.8) | Pathway #1 — WARN and Stage 3 no longer escalate to `kill_extension_host()`; defer to EMERGENCY/Stage 4. WARN threshold raised to 3.0 GB (above steady-state baseline). Prevents watchdog from destroying its own editing session at non-emergency RSS. | ✅ Fixed |
 | WARN cgroup fallback (v20260326.3) | Pathway #1 — when no kill candidate exists at WARN, triggers `cgroup_throttle()` + `cgroup_reclaim()` as non-destructive intermediate relief. EMERGENCY resets `_action_taken` so non-critical kills cannot block it. | ✅ Fixed |
+| Threshold raise for AI workloads (v20260326.4) | Pathway #1 — WARN 3.0→3.4 GB, EMERG 3.2→3.8 GB, STARTUP_WARN 3.2→3.6 GB, STARTUP_EMERG 3.4→4.0 GB. Copilot Chat multi-agent research legitimately peaks at 3.0–3.5 GB; previous thresholds gave only 300 MB headroom. | ✅ Fixed |
 | Container swap | Pathway #1 — direct relief for container kernel OOM | ❌ Blocked (CapEff=0, see §4) |
 
 **Residual risk:** The container kernel can still OOM if VS Code + idle MCP browser + a Playwright session all run simultaneously without the MCP browser being killed first. The watchdog mitigates this but cannot guarantee prevention if the spike is faster than the 2s polling interval.

--- a/docs/workflow/learnings.md
+++ b/docs/workflow/learnings.md
@@ -20,6 +20,27 @@
 
 ---
 
+### 2026-03-26 — RSS thresholds must account for Copilot Chat multi-agent memory peaks
+
+**Context**: VS Code crashed at 12:44:57. Daemon v20260326.3 (just deployed with cgroup fallback fix) triggered `kill_vscode_main` at STARTUP_RSS_EMERG_KB=3,400,000 during legitimate Copilot Chat multi-agent research.
+
+**Discovery**: Copilot Chat multi-agent workloads (research mode with multiple tool calls, web fetches, and large context windows) legitimately drive VS Code aggregate RSS to 3.0–3.5 GB. The crash sequence was: 2,328 MB (12:44:10) → 3,114 MB (12:44:32, ACCEL +468 MB) → 3,300 MB (12:44:56, BURST) → 3,423 MB (12:44:57, EMERGENCY → `kill_vscode_main`). No Chrome, no helper candidate, dmesg clean (no kernel OOM). The previous STARTUP_RSS_EMERG_KB=3,400,000 gave only 300 MB headroom above normal Copilot Chat peaks — the threshold was tuned for pre-AI workloads.
+
+**Fixes applied (v20260326.4)**:
+- VSCODE_RSS_WARN_KB: 3,000,000 → 3,400,000 (3.4 GB)
+- VSCODE_RSS_EMERG_KB: 3,200,000 → 3,800,000 (3.8 GB)
+- STARTUP_RSS_WARN_KB: 3,200,000 → 3,600,000 (3.6 GB)
+- STARTUP_RSS_EMERG_KB: 3,400,000 → 4,000,000 (4.0 GB)
+- Extension defaults (package.json) and configWriter.js safe fallbacks updated to match.
+
+**Application**:
+- RSS thresholds must be calibrated against the **heaviest legitimate workload**, not the baseline idle state. On this system, Copilot Chat multi-agent is the heaviest workload, peaking at 3.0–3.5 GB.
+- EMERG should have ≥ 600 MB headroom above the heaviest legitimate peak (3.5 GB + 0.3 GB = 3.8 GB for EMERG, 3.5 GB + 0.5 GB = 4.0 GB for STARTUP_EMERG).
+- When a crash occurs with no Chrome running, no helper candidate, and a clean dmesg, the most likely cause is thresholds set below the legitimate workload peak — not a code bug.
+- Config override files (`~/.config/mem-watchdog/config.sh`) must be updated alongside daemon defaults, since they override the daemon's built-in values.
+
+---
+
 ### 2026-03-26 — WARN dead zone: no cgroup fallback when no kill candidate exists
 
 **Context**: VS Code crashed at 12:15:03 during process priority research. Journal showed 18 consecutive WARN polls (3.0–3.1 GB RSS, 74% free, no Chrome) with `helper_no_candidate=301`. No cgroup throttle or reclaim was triggered at WARN level.


### PR DESCRIPTION
Post-merge governance docs for PR #78 (#77 fix).

- **system-stability.md §8**: crash entry for 12:44:57 + post-fix row
- **system-stability.md §9**: new risk mitigation row for v20260326.4 threshold raise
- **learnings.md**: new entry on RSS threshold calibration for AI workloads
- **copilot-instructions.md**: updated kill hierarchy table thresholds (WARN 3.4 GB, EMERG 3.8 GB, STARTUP_WARN 3.6 GB, STARTUP_EMERG 4.0 GB)