### PR TITLE
docs(daemon): post-merge governance for process classification fix (#80)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,7 +48,7 @@ vscode-extension/
 | `MemAvailable ≤ 25%` | `SIGTERM` Chrome/Playwright |
 | PSI `full avg10 > 25%` | `SIGTERM` Chrome/Playwright |
 | VS Code RSS ≥ `VSCODE_RSS_EMERG_KB` (3.8 GB) | `SIGKILL` Chrome; if no Chrome → `kill_vscode_main()` |
-| VS Code RSS ≥ `VSCODE_RSS_WARN_KB` (3.4 GB) | `SIGTERM` Chrome + desktop alert; if no Chrome → `kill_top_vscode_helper()`; if no candidate → log and defer to EMERGENCY |
+| VS Code RSS ≥ `VSCODE_RSS_WARN_KB` (3.4 GB) | `SIGTERM` Chrome + desktop alert; if no Chrome → `kill_top_vscode_helper()` (Shared Process, File Watcher, Network Service ≈300 MB); if no candidate → cgroup throttle/reclaim, defer to EMERGENCY |
 | RSS delta ≥ `RSS_ACCEL_KB` (300 MB/cycle) **AND** `vscode_rss ≥ eff_warn` | `kill_top_vscode_helper()` or `kill_browsers(TERM)` |
 | `RSS_RUNAWAY_STREAK=3` consecutive ACCEL cycles above `RSS_RUNAWAY_MIN_KB` (2.6 GB) | Circuit-breaker: `kill_vscode_main()` |
 
@@ -57,6 +57,8 @@ vscode-extension/
 **Startup mode**: 0.5s polling for 90s after new VS Code PIDs appear. Debounced at `STARTUP_DEBOUNCE=300s` — without this guard, language-server PID churn triggered startup mode 567 times in one day. Startup thresholds: `STARTUP_RSS_WARN_KB=3600000`, `STARTUP_RSS_EMERG_KB=4000000`.
 
 **Action budget** (`utils.js`-equivalent in daemon): `action_budget_allows()` limits non-critical interventions to `ACTION_BUDGET_MAX=6` per `ACTION_BUDGET_WINDOW=30s`, and enforces at most one action per loop iteration (`_action_taken` flag). Prevents thrash storms under rapid-fire ACCEL or BURST triggers. **EMERGENCY resets `_action_taken=false`** before processing — non-critical kills (e.g., ACCEL tsserver) cannot block emergency response. When `kill_top_vscode_helper` finds no candidate at WARN with no Chrome, triggers `cgroup_throttle()` + `cgroup_reclaim()` as non-destructive fallback.
+
+**Process classification** (`find_pty_host_pid()`): PTY Host is identified at runtime as the only `node.mojom.NodeService` utility with child processes (bash terminals). Other utility processes (Shared Process, File Watcher, Network Service) are eligible kill candidates at WARN level. ExtHost excluded by `--inspect-port`.
 
 **`kill_vscode_main()`**: SIGTERM on the VS Code main process (identified by `/usr/share/code/code$` cmdline). Used as circuit-breaker only — gated by `CODE_RECOVERY_COOLDOWN=30s`. Causes VS Code window restart, which is preferable to kernel OOM-kill.
 

--- a/docs/technical/system-stability.md
+++ b/docs/technical/system-stability.md
@@ -177,6 +177,7 @@ Setting this to **512 MB** (the original value) was counterproductive:
 | 2026-03-26 post-#74 | 0 | Daemon v20260326.3: WARN fallback triggers `cgroup_throttle()` + `cgroup_reclaim()` when no kill candidate exists. EMERGENCY resets `_action_taken=false` — non-critical kills cannot block emergency. No-candidate log suppressed after first occurrence. |
 | 2026-03-26 12:44:57 | 1 | Thresholds too low for Copilot Chat multi-agent workloads. RSS grew 2,328→3,114→3,300→3,423 MB in 47s during legitimate research. No Chrome, no helper candidate. STARTUP_RSS_EMERG_KB=3,400,000 gave only 300 MB above Copilot peak → `kill_vscode_main`. No kernel OOM (dmesg clean). (issue #77, daemon v20260326.4) |
 | 2026-03-26 post-#77 | 0 | Daemon v20260326.4: WARN 3.0→3.4 GB, EMERG 3.2→3.8 GB, STARTUP_WARN 3.2→3.6 GB, STARTUP_EMERG 3.4→4.0 GB. Extension defaults and configWriter fallbacks updated to match. |
+| 2026-03-26 post-#80 | 0 | Daemon v20260326.5: Process classification gap fixed. Blanket `--type=utility` exclusion replaced with targeted PTY Host PID exclusion via `find_pty_host_pid()`. `kill_top_vscode_helper("normal")` now has 2–3 candidates (Shared Process, File Watcher, Network Service ≈300 MB) when no Chrome is running. (issue #80, PR #81) |
 
 ### The 2026-03-05 crash — what was fixed
 
@@ -201,6 +202,7 @@ Three root causes:
 | WARN-deferral fix (v20260325.8) | Pathway #1 — WARN and Stage 3 no longer escalate to `kill_extension_host()`; defer to EMERGENCY/Stage 4. WARN threshold raised to 3.0 GB (above steady-state baseline). Prevents watchdog from destroying its own editing session at non-emergency RSS. | ✅ Fixed |
 | WARN cgroup fallback (v20260326.3) | Pathway #1 — when no kill candidate exists at WARN, triggers `cgroup_throttle()` + `cgroup_reclaim()` as non-destructive intermediate relief. EMERGENCY resets `_action_taken` so non-critical kills cannot block it. | ✅ Fixed |
 | Threshold raise for AI workloads (v20260326.4) | Pathway #1 — WARN 3.0→3.4 GB, EMERG 3.2→3.8 GB, STARTUP_WARN 3.2→3.6 GB, STARTUP_EMERG 3.4→4.0 GB. Copilot Chat multi-agent research legitimately peaks at 3.0–3.5 GB; previous thresholds gave only 300 MB headroom. | ✅ Fixed |
+| Process classification fix (v20260326.5) | Pathway #1 — `kill_top_vscode_helper("normal")` now has intermediate candidates (Shared Process, File Watcher, Network Service ≈300 MB) between WARN cgroup throttle and EMERGENCY `kill_vscode_main`. PTY Host excluded by PID (child-detection), not blanket `--type=utility`. | ✅ Fixed |
 | Container swap | Pathway #1 — direct relief for container kernel OOM | ❌ Blocked (CapEff=0, see §4) |
 
 **Residual risk:** The container kernel can still OOM if VS Code + idle MCP browser + a Playwright session all run simultaneously without the MCP browser being killed first. The watchdog mitigates this but cannot guarantee prevention if the spike is faster than the 2s polling interval.

--- a/docs/workflow/learnings.md
+++ b/docs/workflow/learnings.md
@@ -20,6 +20,25 @@
 
 ---
 
+### 2026-03-26 — Blanket process-type exclusion creates zero-candidate dead zones
+
+**Context**: After fixing the WARN dead zone (#74) and threshold raise (#77), analysis of `kill_top_vscode_helper("normal")` revealed it still produced **zero candidates** when no Chrome was running. Every VS Code process was either EXCLUDED (main, zygote, GPU, ExtHost via `--inspect-port`, all `--type=utility`) or PROTECTED (tsserver, language servers, eslint).
+
+**Discovery**: The blanket `--type=utility` exclusion added in v20260325.5 (#55) was intended to protect the PTY Host (killing it destroys terminal sessions) and Extension Host (already covered by `--inspect-port`). But it also blocked 3 auto-recoverable utility processes: Shared Process (~113 MB), File Watcher (~111 MB), and Network Service (~76 MB) — totaling ~300 MB of intermediate relief. The critical insight: PTY Host is identifiable at runtime as the **only** `node.mojom.NodeService` utility that has child processes (bash terminals). All other NodeService utilities (Shared Process, File Watcher) have 0 children. Network Service uses a different sub-type (`network.mojom.NetworkService`). This means we can exclude PTY Host by PID rather than by type.
+
+**Fixes applied (v20260326.5)**:
+- Added `find_pty_host_pid()`: loops over NodeService utility PIDs, identifies the one with child processes via `ps --ppid`.
+- Replaced `if (md != "emerg" && args ~ /--type=utility/) next;` with `if (md != "emerg" && pid == pty_host) next;` in all 3 awk blocks.
+- PTY Host PID passed as awk `-v pty_host=` variable, pre-computed once per `kill_top_vscode_helper` call.
+- Verified: 2 candidates now available at WARN (was 0).
+
+**Application**:
+- When protecting a specific process from a broad exclusion, always use the most specific differentiator available. For PTY Host: child processes. For ExtHost: `--inspect-port`. Never use a broad type flag (`--type=utility`) to protect one process when it blocks many.
+- After any exclusion change, verify the candidate pool with a live simulation (`ps -C code | awk ...`) — not just code review. The previous 5 exclusion patches (#45, #46, #47, #55, #64) were each correct in isolation but their cumulative effect was zero candidates.
+- Process classification should be done at a pre-computation stage (bash function → PID → awk variable), not inside awk regex matching, when the differentiator requires parent-child relationship checks.
+
+---
+
 ### 2026-03-26 — RSS thresholds must account for Copilot Chat multi-agent memory peaks
 
 **Context**: VS Code crashed at 12:44:57. Daemon v20260326.3 (just deployed with cgroup fallback fix) triggered `kill_vscode_main` at STARTUP_RSS_EMERG_KB=3,400,000 during legitimate Copilot Chat multi-agent research.


### PR DESCRIPTION
## Summary

Post-merge governance documentation for PR #81 (process classification gap fix, issue #80).

### Changes
- **system-stability.md**: Added crash history row for v20260326.5 and mitigation table row for process classification fix
- **learnings.md**: New entry — "Blanket process-type exclusion creates zero-candidate dead zones"
- **copilot-instructions.md**: Updated kill hierarchy table (WARN candidates) and added process classification paragraph documenting `find_pty_host_pid()`

### Gate evidence
Pre-push hook passed: docs-integrity-check 4/4 ✓

Closes: N/A (governance docs for already-merged #80)