### PR TITLE
feat(extension): add global Copilot skill + @memwatchdog chat participant

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,14 +14,17 @@ mem-watchdog.service     ← systemd user unit (systemctl --user, NOT system)
 install.sh               ← shell-only installer (no VS Code required)
 test-watchdog.sh         ← 18-test suite; exits 0/1; logs to scratch/
 vscode-extension/
-  extension.js           ← activate(): install → config → commands → status bar (2s poll) → update check
+  extension.js           ← activate(): install → skill → config → commands → status bar (2s poll) → update check → chat
   installer.js           ← SHA-256 hash-based daemon auto-install/upgrade + MIN_SAFE guard
   configWriter.js        ← VS Code Settings → ~/.config/mem-watchdog/config.sh
   commands.js            ← 4 commands: dashboard, preflight, killChrome, restartService
   updateChecker.js       ← GitHub Releases API self-update check (24h throttled, non-blocking)
+  skillInstaller.js      ← installs/updates ~/.copilot/skills/mem-watchdog-ops/ on activation
+  chatParticipant.js     ← @memwatchdog chat participant: /status, /logs, /tune, /act
   utils.js               ← readMeminfo(), sh(), checkServiceStatus() — shared helpers
   lifecycle.js           ← vscode:uninstall hook; stops + disables the service
   scripts/prepare.js     ← vscode:prepublish: copies daemon files → resources/
+  skills/mem-watchdog-ops/ ← bundled Copilot skill (SKILL.md + watchdog-snapshot.sh)
   resources/             ← BUILD ARTIFACT (gitignored); bundled into .vsix by vsce
 ```
 
@@ -75,7 +78,7 @@ EXPLORE → PLAN → IMPLEMENT → GATE → REFLECT → COMMIT
 bash test-watchdog.sh                                                          # 18 bash tests, ~3s
 bash -n mem-watchdog.sh                                                        # syntax check
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh
-cd vscode-extension && npm test                                                # 75 JS unit tests, ~1s
+cd vscode-extension && npm test                                                # 100 JS unit tests, ~1s
 bash scripts/docs-integrity-check.sh                                           # docs drift check
 ```
 
@@ -88,7 +91,7 @@ bash scripts/docs-integrity-check.sh                                           #
 ```bash
 cd vscode-extension
 npm run build              # populate resources/ for dev (gitignored; required before vsce package)
-npm test                   # 75 unit tests via node:test (~1s)
+npm test                   # 100 unit tests via node:test (~1s)
 npm run test:coverage      # + c8 V8 lcov output
 npm run test:stress        # pileup guard + event-loop lag + heap scenarios
 npx vsce package           # → mem-watchdog-status-x.y.z.vsix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@
 #
 #   bash test-watchdog.sh   # on your Crostini machine
 #
-# The CI gate covers: daemon syntax, shellcheck, all 75 JS unit tests, and docs integrity.
+# The CI gate covers: daemon syntax, shellcheck, all 100 JS unit tests, and docs integrity.
 # ──────────────────────────────────────────────────────────────────────────────
 
 name: CI
@@ -74,7 +74,7 @@ jobs:
         run: npm ci
         working-directory: vscode-extension
 
-      - name: npm test (75 unit tests)
+      - name: npm test (100 unit tests)
         run: npm test
         working-directory: vscode-extension
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: PolyForm NC](https://img.shields.io/badge/License-PolyForm%20NC%201.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-ChromeOS%20Crostini-4285f4)](https://chromeos.dev/en/linux)
 [![Tests](https://img.shields.io/badge/bash-18%2F18-brightgreen)](test-watchdog.sh)
-[![Tests](https://img.shields.io/badge/js-75%2F75-brightgreen)](vscode-extension/package.json)
+[![Tests](https://img.shields.io/badge/js-100%2F100-brightgreen)](vscode-extension/package.json)
 
 _`earlyoom` hard-crashes on Crostini (exit 104, every 3 seconds, zero protection). This replaces it with a VS Code-aware watchdog that kills Chrome before the kernel OOM-kills VS Code._
 
@@ -156,7 +156,7 @@ All 4 gates must pass before any change is published:
 
 ```bash
 bash test-watchdog.sh              # 18 bash tests (~3 s) — service, OOM scores, PSI, SwapFree safety, SIGTERM
-cd vscode-extension && npm test    # 75 JS unit tests (~1 s) — extension state machine, activation singleton, pileup guard, utils
+cd vscode-extension && npm test    # 100 JS unit tests (~1 s) — extension state machine, activation singleton, pileup guard, utils
 bash -n mem-watchdog.sh            # bash syntax check
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh
 ```

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.3.8] — 2026-03-26
+
+### Added
+- **`@memwatchdog` chat participant** (`chatParticipant.js`) — Copilot Chat integration with four slash commands:
+  - `/memwatchdog status` — RAM%, VS Code RSS, PSI, service state snapshot
+  - `/memwatchdog logs` — last 40 journal lines from the daemon
+  - `/memwatchdog tune <profile>` — apply `balanced`, `conservative`, or `playwright` tuning profile
+  - `/memwatchdog act <action>` — kill Chrome, restart service, or open dashboard
+  - Followup suggestions after each command for natural conversation flow
+  - Graceful no-op when Chat API is unavailable (VS Code < 1.93)
+- **`chatSkills` contribution** — bundled `skills/mem-watchdog-ops/SKILL.md` enables Copilot to carry watchdog-specific operational context across all repositories
+- **User-level Copilot skill installer** (`skillInstaller.js`) — on activation, installs or refreshes `~/.copilot/skills/mem-watchdog-ops/` with SKILL.md and `watchdog-snapshot.sh` helper script
+- **Tuning profiles** aligned with daemon v20260326.5 defaults:
+  - `balanced`: warn 3.4 GB, emerg 3.8 GB (matches current daemon)
+  - `conservative`: warn 3.0 GB, emerg 3.4 GB (earlier intervention)
+  - `playwright`: warn 3.8 GB, emerg 4.2 GB (headroom for automation)
+
+### Tests
+- JS unit tests: 75 → **100 passing**
+- Added `chatParticipant.test.js` — 20 tests covering detectProfile, applyProfile, all 4 requestHandler commands (/status, /logs, /tune, /act), null meminfo, followup providers, chat API unavailable
+- Added `skillInstaller.test.js` — 3 tests covering install/update/skip states and executable permissions
+
 ## [0.3.7] — 2026-03-25
 
 ### Fixed

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -53,6 +53,23 @@ Access all commands via `Ctrl+Shift+P` → **Mem Watchdog:**
 
 ---
 
+## Copilot Chat Integration
+
+Type `@memwatchdog` in Copilot Chat for AI-assisted memory operations:
+
+| Command | Description |
+|---|---|
+| `/memwatchdog status` | RAM%, VS Code RSS, PSI, service state snapshot |
+| `/memwatchdog logs` | Last 40 journal lines with action markers |
+| `/memwatchdog tune balanced` | Apply a tuning profile (balanced / conservative / playwright) |
+| `/memwatchdog act kill chrome` | Kill Chrome, restart service, or open dashboard |
+
+The extension also installs a Copilot skill at `~/.copilot/skills/mem-watchdog-ops/` so the assistant carries watchdog context across all repositories.
+
+> Requires VS Code ≥ 1.93 for Chat API. On older versions the chat participant is silently skipped.
+
+---
+
 ## Settings
 
 Configure all thresholds via **VS Code Settings → Mem Watchdog**. Changes take effect immediately — the extension rewrites `~/.config/mem-watchdog/config.sh` and restarts the daemon automatically.
@@ -62,8 +79,8 @@ Configure all thresholds via **VS Code Settings → Mem Watchdog**. Changes take
 | `sigtermThresholdPct` | `25` | `SIGTERM` Chrome when `MemAvailable` falls below this % of total RAM |
 | `sigkillThresholdPct` | `15` | Escalate to `SIGKILL` below this % |
 | `psiThresholdPct` | `25` | `SIGTERM` on PSI `full avg10` above this % |
-| `vscodeRssWarnMB` | `3000` | Warn + `SIGTERM` Chrome when total VS Code RSS exceeds this many MB |
-| `vscodeRssEmergencyMB` | `3500` | `SIGKILL` Chrome (or `SIGTERM` extension host) above this MB |
+| `vscodeRssWarnMB` | `3400` | Warn + `SIGTERM` Chrome when total VS Code RSS exceeds this many MB |
+| `vscodeRssEmergencyMB` | `3800` | `SIGKILL` Chrome (or `SIGTERM` extension host) above this MB |
 
 > All settings use `scope: "machine"` — they do **not** sync across machines via Settings Sync. A threshold tuned for 6 GB RAM would be dangerously wrong on a 16 GB machine.
 
@@ -101,8 +118,10 @@ VS Code Extension (this)            Systemd Daemon (independent process)
 
 On every VS Code activation:
 1. The bundled `mem-watchdog.sh` is SHA-256 compared to the installed version. If different, it is upgraded and the service is restarted automatically.
-2. VS Code Settings are written to `~/.config/mem-watchdog/config.sh`. The daemon sources this file so threshold changes take effect on the next restart — without reinstalling.
-3. OOM scores are tuned: `oom_score_adj=0` for VS Code (counters Electron's default 200–300), `oom_score_adj=1000` for Chrome (kernel kills it first, no root required).
+2. A Copilot skill is installed/refreshed at `~/.copilot/skills/mem-watchdog-ops/`.
+3. VS Code Settings are written to `~/.config/mem-watchdog/config.sh`. The daemon sources this file so threshold changes take effect on the next restart — without reinstalling.
+4. OOM scores are tuned: `oom_score_adj=0` for VS Code (counters Electron's default 200–300), `oom_score_adj=1000` for Chrome (kernel kills it first, no root required).
+5. If the Chat API is available, the `@memwatchdog` chat participant is registered.
 
 The extension is OOM-resilient by design: it reads kernel virtual files directly rather than spawning processes that could themselves fail under `ENOMEM` — the exact condition it is monitoring.
 
@@ -124,7 +143,7 @@ cd vscode-extension
 npm run build
 npm install -g @vscode/vsce
 vsce package
-code --install-extension mem-watchdog-status-0.3.7.vsix
+code --install-extension mem-watchdog-status-0.3.8.vsix
 ```
 
 Reload the window (`Developer: Reload Window`). The daemon installs and starts automatically on first activation.
@@ -151,9 +170,9 @@ Commercial use requires a paid license. See [COMMERCIAL-LICENSE.md](https://gith
 git clone https://github.com/chf3198/crostini-mem-watchdog.git
 cd crostini-mem-watchdog/vscode-extension
 npm run build          # populate resources/ from repo root
-npm test               # 75 JS unit tests via node:test (zero-install)
+npm test               # 100 JS unit tests via node:test (zero-install)
 npm run test:coverage  # same + c8 V8 coverage report
 npm run test:stress    # stress scenarios: pileup guard, EL lag, heap usage
 ```
 
-75 unit tests covering `readMeminfo`/`readPsi`/`sh()`/`checkServiceStatus()`, config validation, command handlers, installer decision logic, `activate()` singleton lifecycle, the `update()` state machine + pileup guard, update checker (version comparison, throttling, dismissal), and installer MIN_SAFE_DAEMON_VERSION guard.
+100 unit tests covering `readMeminfo`/`readPsi`/`sh()`/`checkServiceStatus()`, config validation, command handlers, installer decision logic, `activate()` singleton lifecycle, the `update()` state machine + pileup guard, update checker (version comparison, throttling, dismissal), installer MIN_SAFE_DAEMON_VERSION guard, skill installer (install/update/skip), and `@memwatchdog` chat participant (all 4 commands, profile detection/application, followups, API availability guard).

--- a/vscode-extension/chatParticipant.js
+++ b/vscode-extension/chatParticipant.js
@@ -1,0 +1,195 @@
+'use strict';
+
+const vscode = require('vscode');
+
+const commands = require('./commands');
+const { readMeminfo, readPsi, sh } = require('./utils');
+
+// ── Chat API detection ────────────────────────────────────────────────────────
+// The Chat API (vscode.chat.createChatParticipant) requires VS Code ≥ 1.93.
+// The extension's engines.vscode is ^1.74.0 so the API may not be available.
+// This runtime guard avoids hard failures on older builds.
+function hasChatApi() {
+    return !!(vscode.chat && typeof vscode.chat.createChatParticipant === 'function');
+}
+
+// ── Tuning profiles ───────────────────────────────────────────────────────────
+// Values are MB for RSS thresholds, percent for MemAvailable thresholds.
+// Aligned with daemon defaults (v20260326.5): warn=3400, emerg=3800.
+const PROFILES = {
+    balanced:     { warn: 3400, emerg: 3800, sigterm: 25, sigkill: 15 },
+    conservative: { warn: 3000, emerg: 3400, sigterm: 28, sigkill: 18 },
+    playwright:   { warn: 3800, emerg: 4200, sigterm: 22, sigkill: 12 },
+};
+
+function detectProfile(prompt = '') {
+    const p = prompt.toLowerCase();
+    if (/(playwright|headed|automation|browser-heavy)/.test(p)) { return 'playwright'; }
+    if (/(conservative|safe|minimal|low\s*risk)/.test(p)) { return 'conservative'; }
+    if (/(balanced|default|normal)/.test(p)) { return 'balanced'; }
+    return null;
+}
+
+async function applyProfile(profile) {
+    const cfg = vscode.workspace.getConfiguration('memWatchdog');
+    const next = PROFILES[profile];
+    if (!next) { return false; }
+
+    await cfg.update('vscodeRssWarnMB', next.warn, vscode.ConfigurationTarget.Global);
+    await cfg.update('vscodeRssEmergencyMB', next.emerg, vscode.ConfigurationTarget.Global);
+    await cfg.update('sigtermThresholdPct', next.sigterm, vscode.ConfigurationTarget.Global);
+    await cfg.update('sigkillThresholdPct', next.sigkill, vscode.ConfigurationTarget.Global);
+    return true;
+}
+
+// ── Status rendering ──────────────────────────────────────────────────────────
+
+async function renderStatus() {
+    const mem = readMeminfo();
+    const psi = readPsi();
+    const svc = await sh('systemctl --user is-active mem-watchdog 2>/dev/null || echo unknown');
+    const vsRssResult = await sh('ps -C code -o rss= 2>/dev/null');
+    const vscodeRssKB = (vsRssResult.stdout || '')
+        .split('\n')
+        .filter(Boolean)
+        .reduce((s, n) => s + (parseInt(n, 10) || 0), 0);
+
+    if (!mem) {
+        return `### Mem Watchdog Status\n\n` +
+            `- Service: **${(svc.stdout || 'unknown').trim()}**\n` +
+            `- /proc/meminfo: unreadable\n` +
+            `- PSI full avg10: ${(psi / 100).toFixed(2)}%\n`;
+    }
+
+    return [
+        '### Mem Watchdog Status',
+        '',
+        `- Service: **${(svc.stdout || 'unknown').trim()}**`,
+        `- RAM free: **${mem.pct.toFixed(1)}%** (${Math.round(mem.availableKB / 1024)} MB available)`,
+        `- VS Code RSS: **${Math.round(vscodeRssKB / 1024)} MB**`,
+        `- PSI full avg10: **${(psi / 100).toFixed(2)}%**`,
+        '',
+        'Use `/memwatchdog logs` for recent journal actions, or `/memwatchdog tune <profile>`.',
+    ].join('\n');
+}
+
+// ── Request handler ───────────────────────────────────────────────────────────
+
+async function requestHandler(request, _context, stream) {
+    const command = request.command || 'status';
+    const prompt = request.prompt || '';
+
+    if (command === 'status') {
+        stream.markdown(await renderStatus());
+        stream.button({ command: 'memWatchdog.showDashboard', title: 'Open Dashboard' });
+        stream.button({ command: 'memWatchdog.restartService', title: 'Restart Service' });
+        return { metadata: { command } };
+    }
+
+    if (command === 'logs') {
+        const { stdout } = await sh(
+            'journalctl --user -u mem-watchdog -n 40 --no-pager --output=short-monotonic 2>/dev/null || true'
+        );
+        stream.markdown('### Recent mem-watchdog journal\n');
+        stream.markdown('```text\n' + (stdout || '(no logs found)') + '\n```');
+        stream.button({ command: 'memWatchdog.showDashboard', title: 'Open Dashboard' });
+        return { metadata: { command } };
+    }
+
+    if (command === 'act') {
+        const p = prompt.toLowerCase();
+        if (p.includes('kill') || p.includes('chrome')) {
+            await commands.killChrome();
+            stream.markdown('Sent `SIGTERM` to Chrome/Playwright targets.');
+        } else if (p.includes('restart') || p.includes('service')) {
+            await commands.restartService();
+            stream.markdown('Restarted `mem-watchdog` service (or attempted restart).');
+        } else {
+            await commands.showDashboard();
+            stream.markdown('Opened the Mem Watchdog dashboard.');
+        }
+        return { metadata: { command } };
+    }
+
+    if (command === 'tune') {
+        const profile = detectProfile(prompt);
+        if (!profile) {
+            stream.markdown(
+                'Specify a profile: `balanced`, `conservative`, or `playwright`.\n\n' +
+                'Examples:\n' +
+                '- `/memwatchdog tune balanced`\n' +
+                '- `/memwatchdog tune conservative`\n' +
+                '- `/memwatchdog tune playwright`'
+            );
+            return { metadata: { command } };
+        }
+
+        const ok = await applyProfile(profile);
+        if (ok) {
+            stream.markdown(`Applied **${profile}** profile to Mem Watchdog settings.`);
+            stream.markdown(
+                'The extension settings listener will restart the service to load the new config.'
+            );
+            stream.button({ command: 'memWatchdog.showDashboard', title: 'Open Dashboard' });
+        } else {
+            stream.markdown('Could not apply profile.');
+        }
+        return { metadata: { command } };
+    }
+
+    // Unrecognised command → default to status
+    stream.markdown(await renderStatus());
+    return { metadata: { command: 'status' } };
+}
+
+// ── Registration ──────────────────────────────────────────────────────────────
+
+function registerChatParticipant(context) {
+    if (!hasChatApi()) { return; }
+
+    const participant = vscode.chat.createChatParticipant(
+        'mem-watchdog-status.memWatchdogAssistant',
+        requestHandler,
+    );
+
+    participant.followupProvider = {
+        provideFollowups(result) {
+            const last = result?.metadata?.command;
+            if (last === 'status') {
+                return [
+                    { prompt: '/memwatchdog logs', label: 'Show recent logs' },
+                    { prompt: '/memwatchdog tune conservative', label: 'Apply conservative profile' },
+                ];
+            }
+            if (last === 'logs') {
+                return [
+                    { prompt: '/memwatchdog status', label: 'Refresh status snapshot' },
+                    { prompt: '/memwatchdog act restart service', label: 'Restart service' },
+                ];
+            }
+            return [
+                { prompt: '/memwatchdog status', label: 'Show status' },
+                { prompt: '/memwatchdog tune balanced', label: 'Apply balanced profile' },
+            ];
+        },
+    };
+
+    context.subscriptions.push(participant);
+}
+
+module.exports = {
+    registerChatParticipant,
+    PROFILES,
+};
+
+// ── Test-only exports ─────────────────────────────────────────────────────────
+/* c8 ignore next */
+if (process.env.MEM_WATCHDOG_TEST) {
+    module.exports._test = {
+        hasChatApi,
+        detectProfile,
+        applyProfile,
+        renderStatus,
+        requestHandler,
+    };
+}

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -2,11 +2,13 @@
 // ─────────────────────────────────────────────────────────────────────────────
 // On activation:
 //   1. Installs / upgrades the daemon (installer.js)
+//   1b. Install / refresh user-level Copilot skill (skillInstaller.js)
 //   2. Writes VS Code settings → ~/.config/mem-watchdog/config.sh (configWriter.js)
 //   3. Registers 4 commands (commands.js)
 //   4. Watches for settings changes → rewrites config + restarts daemon
 //   5. Runs the status bar status poller every 2 s (original logic preserved)
 //   6. Deferred self-update check via GitHub Releases API (updateChecker.js)
+//   7. Optional @memwatchdog chat participant (chatParticipant.js)
 // ─────────────────────────────────────────────────────────────────────────────
 'use strict';
 
@@ -16,6 +18,8 @@ const installer    = require('./installer');
 const configWriter = require('./configWriter');
 const commands     = require('./commands');
 const updateChecker = require('./updateChecker');
+const { installGlobalSkill } = require('./skillInstaller');
+const { registerChatParticipant } = require('./chatParticipant');
 const { readMeminfo, sh, checkServiceStatus } = require('./utils');
 
 // ── Status bar poll interval ──────────────────────────────────────────────────
@@ -161,6 +165,18 @@ async function activate(context) {
         vscode.window.showErrorMessage(`Mem Watchdog: install failed — ${err.message}`);
     }
 
+    // ── 1b. Install / refresh user-level Copilot skill ─────────────────────
+    // Installs to ~/.copilot/skills/mem-watchdog-ops so the assistant can
+    // carry watchdog-specific operational context across repositories.
+    try {
+        const skill = installGlobalSkill(context.extensionUri.fsPath);
+        if (skill.state === 'installed') {
+            vscode.window.showInformationMessage('Mem Watchdog: Copilot skill installed ✓');
+        }
+    } catch (err) {
+        console.error('[memWatchdog] skillInstaller error:', err.message);
+    }
+
     // ── 2. Sync VS Code settings → config file ────────────────────────────────
     try {
         const cfgWarnings = configWriter.writeConfig(vscode.workspace.getConfiguration('memWatchdog'));
@@ -236,6 +252,9 @@ async function activate(context) {
     // critical daemon fixes in newer versions.
     const updateTimer = setTimeout(() => updateChecker.checkForUpdate(context), 10_000);
     context.subscriptions.push({ dispose: () => clearTimeout(updateTimer) });
+
+    // ── 7. Optional chat participant (if Chat API is available) ─────────────
+    registerChatParticipant(context);
 }
 
 function deactivate() {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "mem-watchdog-status",
   "displayName": "Mem Watchdog",
   "description": "Prevents VS Code from being OOM-killed on ChromeOS Crostini — auto-installs a systemd memory watchdog daemon that kills Chrome/Playwright before the kernel kills VS Code.",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "publisher": "CurtisFranks",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
@@ -132,7 +132,51 @@
           "markdownDescription": "Emergency: `SIGKILL` Chrome (or `SIGTERM` highest-RSS ext host if no Chrome) when VS Code RSS exceeds this many MB. Default: `3800` (3.8 GB)."
         }
       }
-    }
+    },
+    "chatParticipants": [
+      {
+        "id": "mem-watchdog-status.memWatchdogAssistant",
+        "name": "memwatchdog",
+        "fullName": "Mem Watchdog Assistant",
+        "description": "Inspect watchdog status and logs, and apply memory tuning profiles",
+        "isSticky": true,
+        "commands": [
+          {
+            "name": "status",
+            "description": "Show memory and watchdog status snapshot"
+          },
+          {
+            "name": "logs",
+            "description": "Show recent mem-watchdog journal lines"
+          },
+          {
+            "name": "tune",
+            "description": "Apply a memory profile: balanced, conservative, or playwright"
+          },
+          {
+            "name": "act",
+            "description": "Run watchdog action: kill chrome, restart service, or open dashboard"
+          }
+        ],
+        "disambiguation": [
+          {
+            "category": "watchdog-ops",
+            "description": "Questions about mem-watchdog behavior, Linux memory pressure, watchdog logs, and tuning thresholds for constrained environments.",
+            "examples": [
+              "Show mem-watchdog status and RAM pressure",
+              "Tail watchdog logs and explain recent kill actions",
+              "Switch to a conservative memory profile",
+              "Kill Chrome now to protect VS Code"
+            ]
+          }
+        ]
+      }
+    ],
+    "chatSkills": [
+      {
+        "path": "./skills/mem-watchdog-ops/SKILL.md"
+      }
+    ]
   },
   "devDependencies": {
     "c8": "^11.0.0"

--- a/vscode-extension/skillInstaller.js
+++ b/vscode-extension/skillInstaller.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const SKILL_NAME = 'mem-watchdog-ops';
+
+/**
+ * Install/update the Mem Watchdog personal Copilot skill in ~/.copilot/skills.
+ * Returns a simple state machine for caller UX:
+ *   - installed: destination did not exist and is now created
+ *   - updated: destination existed and was refreshed
+ *   - skipped: bundled skill source is missing
+ *
+ * @param {string} extensionRoot absolute extension install root
+ * @param {{ homeDir?: string, skillRelPath?: string }} [opts]
+ * @returns {{ state: 'installed'|'updated'|'skipped', src?: string, dest?: string, reason?: string }}
+ */
+function installGlobalSkill(extensionRoot, opts = {}) {
+    const homeDir = opts.homeDir || os.homedir();
+    const skillRelPath = opts.skillRelPath || path.join('skills', SKILL_NAME);
+
+    const src = path.join(extensionRoot, skillRelPath);
+    const srcSkill = path.join(src, 'SKILL.md');
+
+    if (!fs.existsSync(srcSkill)) {
+        return { state: 'skipped', reason: `missing ${srcSkill}` };
+    }
+
+    const destRoot = path.join(homeDir, '.copilot', 'skills');
+    const dest = path.join(destRoot, SKILL_NAME);
+    const hadExisting = fs.existsSync(path.join(dest, 'SKILL.md'));
+
+    fs.mkdirSync(destRoot, { recursive: true });
+    fs.cpSync(src, dest, { recursive: true, force: true });
+
+    // Keep helper script executable if present.
+    const helperScript = path.join(dest, 'watchdog-snapshot.sh');
+    if (fs.existsSync(helperScript)) {
+        fs.chmodSync(helperScript, 0o755);
+    }
+
+    return {
+        state: hadExisting ? 'updated' : 'installed',
+        src,
+        dest,
+    };
+}
+
+module.exports = {
+    installGlobalSkill,
+    SKILL_NAME,
+};

--- a/vscode-extension/skills/mem-watchdog-ops/SKILL.md
+++ b/vscode-extension/skills/mem-watchdog-ops/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: mem-watchdog-ops
+description: Operate and tune Crostini Mem Watchdog for low-memory development sessions. Use for status triage, log interpretation, and safe threshold tuning.
+argument-hint: "[goal: status|logs|tune|preflight] [profile: balanced|conservative|playwright]"
+user-invocable: true
+disable-model-invocation: false
+---
+
+# Mem Watchdog Ops Skill
+
+Use this skill when working in constrained Crostini environments where VS Code, Chrome/Playwright, and extension host memory spikes can trigger OOM.
+
+## Ground Rules
+
+- Never read or reason from `SwapFree` values on Crostini.
+- Prefer `systemctl --user` only — never `sudo systemctl`.
+- Treat the mem-watchdog daemon as independent runtime authority.
+- For tuning, use extension settings (`memWatchdog.*`) so the extension writes config and restarts service safely.
+
+## Fast Workflows
+
+1. **Status snapshot**
+   - Use chat participant command: `/memwatchdog status`
+   - Or run helper: `~/.copilot/skills/mem-watchdog-ops/watchdog-snapshot.sh`
+
+2. **Recent actions / diagnosis**
+   - `/memwatchdog logs`
+   - Look for action markers in journal:
+     - `ACTION(SIGTERM):`
+     - `ACTION(SIGKILL):`
+     - `RECOVERY(SIGTERM):`
+
+3. **Apply tuning profile**
+   - `/memwatchdog tune balanced` — general dev use (warn 3.4 GB, emerg 3.8 GB)
+   - `/memwatchdog tune conservative` — earlier intervention (warn 3.0 GB, emerg 3.4 GB)
+   - `/memwatchdog tune playwright` — more headroom for automation (warn 3.8 GB, emerg 4.2 GB)
+
+4. **Manual protective action**
+   - `/memwatchdog act kill chrome`
+   - `/memwatchdog act restart service`
+
+## Tuning Guidance
+
+- **balanced**: general dev use — recommended for Copilot Chat multi-agent workloads that peak at 3.0–3.5 GB
+- **conservative**: earlier intervention, safer on tight RAM — may cause more Chrome kills
+- **playwright**: more headroom for headed browser automation sessions
+
+When recommending profile changes, explain expected trade-off between stability and interruption frequency.
+
+## Kill Hierarchy (daemon v20260326.5+)
+
+| Condition | Action |
+|---|---|
+| `MemAvailable ≤ 15%` | SIGKILL Chrome/Playwright |
+| `MemAvailable ≤ 25%` | SIGTERM Chrome/Playwright |
+| PSI full avg10 > 25% | SIGTERM Chrome |
+| VS Code RSS ≥ 3.8 GB | SIGKILL Chrome; if none → kill_vscode_main() |
+| VS Code RSS ≥ 3.4 GB | SIGTERM Chrome; if none → kill helper (Shared Process, File Watcher, Network Service); if none → cgroup throttle/reclaim |
+| RSS velocity spike | Kill lowest-value helper — never a language server or Extension Host at normal severity |
+
+## Key Repo References
+
+- [Daemon logic](../../mem-watchdog.sh)
+- [Extension activation](../../extension.js)
+- [Dashboard/actions](../../commands.js)
+- [Config bridge](../../configWriter.js)
+- [System stability doc](../../../../docs/technical/system-stability.md)

--- a/vscode-extension/skills/mem-watchdog-ops/watchdog-snapshot.sh
+++ b/vscode-extension/skills/mem-watchdog-ops/watchdog-snapshot.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# watchdog-snapshot.sh — Quick status snapshot for Copilot skill usage.
+# Installed to ~/.copilot/skills/mem-watchdog-ops/ by the VS Code extension.
+
+svc=$(systemctl --user is-active mem-watchdog 2>/dev/null || echo unknown)
+avail=$(awk '/^MemAvailable:/{print $2; exit}' /proc/meminfo 2>/dev/null || echo 0)
+total=$(awk '/^MemTotal:/{print $2; exit}' /proc/meminfo 2>/dev/null || echo 0)
+psi=$(awk '/^full[[:space:]]/{for(i=1;i<=NF;i++){if($i ~ /^avg10=/){sub("avg10=","",$i);print $i; exit}}}' /proc/pressure/memory 2>/dev/null || echo 0)
+vscode_rss=$(ps -C code -o rss= 2>/dev/null | awk '{s+=$1} END{print s+0}')
+chrome_rss=$(ps -eo comm,rss --no-headers 2>/dev/null | awk '$1 ~ /(chrome|chromium)/{s+=$2} END{print s+0}')
+
+pct=0
+if [[ "$total" -gt 0 ]]; then
+  pct=$(( avail * 100 / total ))
+fi
+
+echo "mem-watchdog status: ${svc}"
+echo "mem free: ${pct}% ($((avail / 1024)) MB / $((total / 1024)) MB)"
+echo "psi full avg10: ${psi}%"
+echo "vscode rss: $((vscode_rss / 1024)) MB"
+echo "chrome rss: $((chrome_rss / 1024)) MB"
+echo
+echo "recent journal:"
+journalctl --user -u mem-watchdog -n 15 --no-pager --output=short-monotonic 2>/dev/null || true

--- a/vscode-extension/test/unit/chatParticipant.test.js
+++ b/vscode-extension/test/unit/chatParticipant.test.js
@@ -1,0 +1,297 @@
+// test/unit/chatParticipant.test.js
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests for chatParticipant.js — chat participant handler + profile logic.
+//
+// MOCKING STRATEGY:
+//   chatParticipant.js imports 'vscode', './commands', './utils'.
+//   - 'vscode'    → mockVscode with chat API stubs added
+//   - './commands' → cache-injected mock with killChrome/restartService/showDashboard
+//   - './utils'    → cache-injected mock with readMeminfo/readPsi/sh
+// ─────────────────────────────────────────────────────────────────────────────
+'use strict';
+
+process.env.MEM_WATCHDOG_TEST = '1';
+
+const { test, describe, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path   = require('path');
+
+// ── Step 1: mock 'vscode' with chat API ───────────────────────────────────────
+const { setup: vsSetup, mockVscode, mockWorkspace } = require('../helpers/mockVscode');
+vsSetup();
+
+// Add chat API stub and ConfigurationTarget to mockVscode
+const _createdParticipants = [];
+mockVscode.chat = {
+    createChatParticipant(id, handler) {
+        const p = { id, requestHandler: handler, followupProvider: null, dispose() {} };
+        _createdParticipants.push(p);
+        return p;
+    },
+};
+mockVscode.ConfigurationTarget = { Global: 1, Workspace: 2, WorkspaceFolder: 3 };
+
+// Enhance mock workspace.getConfiguration to track updates
+const _configUpdates = [];
+const origGetConfig = mockWorkspace.getConfiguration.bind(mockWorkspace);
+mockWorkspace.getConfiguration = function(section) {
+    const base = origGetConfig(section);
+    base.update = async function(key, value, target) {
+        _configUpdates.push({ key, value, target });
+    };
+    return base;
+};
+
+// ── Step 2: mock './commands' ─────────────────────────────────────────────────
+const commandsAbsPath = path.resolve(__dirname, '../../commands.js');
+const _commandsCalled = [];
+
+require.cache[commandsAbsPath] = {
+    id: commandsAbsPath, filename: commandsAbsPath, loaded: true, paths: [],
+    exports: {
+        killChrome()     { _commandsCalled.push('killChrome'); return Promise.resolve(); },
+        restartService() { _commandsCalled.push('restartService'); return Promise.resolve(); },
+        showDashboard()  { _commandsCalled.push('showDashboard'); return Promise.resolve(); },
+        preflightCheck() { _commandsCalled.push('preflightCheck'); return Promise.resolve(); },
+        dispose()        {},
+    },
+};
+
+// ── Step 3: mock './utils' ────────────────────────────────────────────────────
+const utilsAbsPath = path.resolve(__dirname, '../../utils.js');
+
+let _mockMeminfo = { totalKB: 6300 * 1024, availableKB: 4600 * 1024, pct: 73.0 };
+let _mockPsi = 0;
+let _mockShResults = {};
+
+require.cache[utilsAbsPath] = {
+    id: utilsAbsPath, filename: utilsAbsPath, loaded: true, paths: [],
+    exports: {
+        readMeminfo() { return _mockMeminfo; },
+        readPsi()     { return _mockPsi; },
+        async sh(cmd) {
+            if (_mockShResults[cmd]) { return _mockShResults[cmd]; }
+            if (cmd.includes('is-active')) { return { ok: true, stdout: 'active\n', stderr: '' }; }
+            if (cmd.includes('ps -C code')) { return { ok: true, stdout: '2867200\n', stderr: '' }; }
+            return { ok: true, stdout: '', stderr: '' };
+        },
+        checkServiceStatus() { return 'active'; },
+    },
+};
+
+// ── Step 4: require chatParticipant.js ────────────────────────────────────────
+const { registerChatParticipant, PROFILES } = require('../../chatParticipant');
+const { _test } = require('../../chatParticipant');
+
+// ── Stream mock ───────────────────────────────────────────────────────────────
+function createMockStream() {
+    const out = { markdowns: [], buttons: [] };
+    return {
+        _out: out,
+        markdown(text) { out.markdowns.push(text); },
+        button(btn)    { out.buttons.push(btn); },
+    };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('chatParticipant — detectProfile()', () => {
+    test('detects playwright profile', () => {
+        assert.equal(_test.detectProfile('Use playwright headed mode'), 'playwright');
+        assert.equal(_test.detectProfile('automation session'), 'playwright');
+    });
+
+    test('detects conservative profile', () => {
+        assert.equal(_test.detectProfile('conservative tuning'), 'conservative');
+        assert.equal(_test.detectProfile('safe mode'), 'conservative');
+    });
+
+    test('detects balanced profile', () => {
+        assert.equal(_test.detectProfile('balanced settings'), 'balanced');
+        assert.equal(_test.detectProfile('use default'), 'balanced');
+    });
+
+    test('returns null for unrecognised prompt', () => {
+        assert.equal(_test.detectProfile('something unrelated'), null);
+        assert.equal(_test.detectProfile(''), null);
+    });
+});
+
+describe('chatParticipant — PROFILES', () => {
+    test('has three profiles with expected keys', () => {
+        assert.deepEqual(Object.keys(PROFILES).sort(), ['balanced', 'conservative', 'playwright']);
+        for (const name of Object.keys(PROFILES)) {
+            const p = PROFILES[name];
+            assert.equal(typeof p.warn, 'number');
+            assert.equal(typeof p.emerg, 'number');
+            assert.equal(typeof p.sigterm, 'number');
+            assert.equal(typeof p.sigkill, 'number');
+        }
+    });
+
+    test('balanced profile matches daemon defaults', () => {
+        assert.equal(PROFILES.balanced.warn, 3400);
+        assert.equal(PROFILES.balanced.emerg, 3800);
+    });
+});
+
+describe('chatParticipant — applyProfile()', () => {
+    beforeEach(() => { _configUpdates.length = 0; });
+
+    test('applies balanced profile settings', async () => {
+        const ok = await _test.applyProfile('balanced');
+        assert.equal(ok, true);
+        assert.equal(_configUpdates.length, 4);
+        assert.equal(_configUpdates[0].key, 'vscodeRssWarnMB');
+        assert.equal(_configUpdates[0].value, 3400);
+        assert.equal(_configUpdates[1].key, 'vscodeRssEmergencyMB');
+        assert.equal(_configUpdates[1].value, 3800);
+    });
+
+    test('returns false for unknown profile', async () => {
+        const ok = await _test.applyProfile('nonexistent');
+        assert.equal(ok, false);
+    });
+});
+
+describe('chatParticipant — requestHandler()', () => {
+    beforeEach(() => {
+        _commandsCalled.length = 0;
+        _mockMeminfo = { totalKB: 6300 * 1024, availableKB: 4600 * 1024, pct: 73.0 };
+        _mockPsi = 0;
+    });
+
+    test('/status renders status markdown with buttons', async () => {
+        const stream = createMockStream();
+        const result = await _test.requestHandler(
+            { command: 'status', prompt: '' }, {}, stream
+        );
+        assert.equal(result.metadata.command, 'status');
+        assert.ok(stream._out.markdowns.some(m => m.includes('Mem Watchdog Status')));
+        assert.ok(stream._out.markdowns.some(m => m.includes('RAM free')));
+        assert.equal(stream._out.buttons.length, 2);
+    });
+
+    test('/status handles null meminfo gracefully', async () => {
+        _mockMeminfo = null;
+        const stream = createMockStream();
+        const result = await _test.requestHandler(
+            { command: 'status', prompt: '' }, {}, stream
+        );
+        assert.equal(result.metadata.command, 'status');
+        assert.ok(stream._out.markdowns.some(m => m.includes('unreadable')));
+    });
+
+    test('/logs renders journal output', async () => {
+        const stream = createMockStream();
+        const result = await _test.requestHandler(
+            { command: 'logs', prompt: '' }, {}, stream
+        );
+        assert.equal(result.metadata.command, 'logs');
+        assert.ok(stream._out.markdowns.some(m => m.includes('journal')));
+    });
+
+    test('/act kill dispatches killChrome', async () => {
+        const stream = createMockStream();
+        await _test.requestHandler(
+            { command: 'act', prompt: 'kill chrome now' }, {}, stream
+        );
+        assert.ok(_commandsCalled.includes('killChrome'));
+    });
+
+    test('/act restart dispatches restartService', async () => {
+        const stream = createMockStream();
+        await _test.requestHandler(
+            { command: 'act', prompt: 'restart the service' }, {}, stream
+        );
+        assert.ok(_commandsCalled.includes('restartService'));
+    });
+
+    test('/act without keyword opens dashboard', async () => {
+        const stream = createMockStream();
+        await _test.requestHandler(
+            { command: 'act', prompt: 'do something' }, {}, stream
+        );
+        assert.ok(_commandsCalled.includes('showDashboard'));
+    });
+
+    test('/tune without profile shows help', async () => {
+        const stream = createMockStream();
+        const result = await _test.requestHandler(
+            { command: 'tune', prompt: '' }, {}, stream
+        );
+        assert.equal(result.metadata.command, 'tune');
+        assert.ok(stream._out.markdowns.some(m => m.includes('Specify a profile')));
+    });
+
+    test('/tune with valid profile applies it', async () => {
+        _configUpdates.length = 0;
+        const stream = createMockStream();
+        const result = await _test.requestHandler(
+            { command: 'tune', prompt: 'use conservative mode' }, {}, stream
+        );
+        assert.equal(result.metadata.command, 'tune');
+        assert.ok(stream._out.markdowns.some(m => m.includes('conservative')));
+        assert.equal(_configUpdates.length, 4);
+    });
+
+    test('unknown command defaults to status', async () => {
+        const stream = createMockStream();
+        const result = await _test.requestHandler(
+            { command: 'unknown', prompt: '' }, {}, stream
+        );
+        assert.equal(result.metadata.command, 'status');
+    });
+});
+
+describe('chatParticipant — registerChatParticipant()', () => {
+    beforeEach(() => { _createdParticipants.length = 0; });
+
+    test('registers participant when chat API is available', () => {
+        const subs = [];
+        const ctx = { subscriptions: subs };
+        registerChatParticipant(ctx);
+        assert.equal(_createdParticipants.length, 1);
+        assert.equal(_createdParticipants[0].id, 'mem-watchdog-status.memWatchdogAssistant');
+        assert.equal(subs.length, 1);
+    });
+
+    test('sets followup provider on participant', () => {
+        const ctx = { subscriptions: [] };
+        registerChatParticipant(ctx);
+        const p = _createdParticipants[0];
+        assert.ok(p.followupProvider);
+        assert.equal(typeof p.followupProvider.provideFollowups, 'function');
+    });
+
+    test('followups after status suggest logs and tune', () => {
+        const ctx = { subscriptions: [] };
+        registerChatParticipant(ctx);
+        const followups = _createdParticipants[0].followupProvider.provideFollowups(
+            { metadata: { command: 'status' } }
+        );
+        assert.ok(followups.some(f => f.prompt.includes('logs')));
+        assert.ok(followups.some(f => f.prompt.includes('tune')));
+    });
+
+    test('followups after logs suggest status and restart', () => {
+        const ctx = { subscriptions: [] };
+        registerChatParticipant(ctx);
+        const followups = _createdParticipants[0].followupProvider.provideFollowups(
+            { metadata: { command: 'logs' } }
+        );
+        assert.ok(followups.some(f => f.prompt.includes('status')));
+        assert.ok(followups.some(f => f.prompt.includes('restart')));
+    });
+
+    test('skips registration when chat API is unavailable', () => {
+        // Temporarily remove chat API
+        const savedChat = mockVscode.chat;
+        mockVscode.chat = undefined;
+        const ctx = { subscriptions: [] };
+        registerChatParticipant(ctx);
+        assert.equal(_createdParticipants.length, 0);
+        assert.equal(ctx.subscriptions.length, 0);
+        mockVscode.chat = savedChat;
+    });
+});

--- a/vscode-extension/test/unit/skillInstaller.test.js
+++ b/vscode-extension/test/unit/skillInstaller.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { installGlobalSkill, SKILL_NAME } = require('../../skillInstaller');
+
+function mkTmp(prefix) {
+    return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+describe('skillInstaller.installGlobalSkill()', () => {
+    test('installs on first run and updates on second run', () => {
+        const extRoot = mkTmp('mw-ext-');
+        const homeDir = mkTmp('mw-home-');
+
+        const srcDir = path.join(extRoot, 'skills', SKILL_NAME);
+        fs.mkdirSync(srcDir, { recursive: true });
+        fs.writeFileSync(path.join(srcDir, 'SKILL.md'), '# skill\n', 'utf8');
+        fs.writeFileSync(path.join(srcDir, 'watchdog-snapshot.sh'), '#!/usr/bin/env bash\necho ok\n', 'utf8');
+
+        const first = installGlobalSkill(extRoot, { homeDir });
+        assert.equal(first.state, 'installed');
+
+        const destSkill = path.join(homeDir, '.copilot', 'skills', SKILL_NAME, 'SKILL.md');
+        assert.equal(fs.existsSync(destSkill), true);
+
+        // Change source and run again -> updated
+        fs.writeFileSync(path.join(srcDir, 'SKILL.md'), '# skill v2\n', 'utf8');
+        const second = installGlobalSkill(extRoot, { homeDir });
+        assert.equal(second.state, 'updated');
+
+        const copied = fs.readFileSync(destSkill, 'utf8');
+        assert.equal(copied.includes('v2'), true);
+    });
+
+    test('skips when bundled skill is missing', () => {
+        const extRoot = mkTmp('mw-ext-empty-');
+        const homeDir = mkTmp('mw-home-empty-');
+
+        const result = installGlobalSkill(extRoot, { homeDir });
+        assert.equal(result.state, 'skipped');
+        assert.equal(typeof result.reason, 'string');
+    });
+
+    test('sets executable permission on helper script', () => {
+        const extRoot = mkTmp('mw-ext-chmod-');
+        const homeDir = mkTmp('mw-home-chmod-');
+
+        const srcDir = path.join(extRoot, 'skills', SKILL_NAME);
+        fs.mkdirSync(srcDir, { recursive: true });
+        fs.writeFileSync(path.join(srcDir, 'SKILL.md'), '# skill\n', 'utf8');
+        fs.writeFileSync(path.join(srcDir, 'watchdog-snapshot.sh'), '#!/usr/bin/env bash\necho ok\n', 'utf8');
+        // Remove executable bits so we can verify the function restores them
+        fs.chmodSync(path.join(srcDir, 'watchdog-snapshot.sh'), 0o644);
+
+        installGlobalSkill(extRoot, { homeDir });
+
+        const destScript = path.join(homeDir, '.copilot', 'skills', SKILL_NAME, 'watchdog-snapshot.sh');
+        const stat = fs.statSync(destScript);
+        // Check that owner-execute bit is set
+        assert.equal((stat.mode & 0o100) !== 0, true, 'owner-execute bit should be set');
+    });
+});


### PR DESCRIPTION
## Summary

Implements two-part Copilot integration (issue #33):

### 1. User-level Copilot skill (`skillInstaller.js`)
On activation, installs/updates `~/.copilot/skills/mem-watchdog-ops/` with:
- **SKILL.md** — operational procedures, tuning guidance, kill hierarchy reference
- **watchdog-snapshot.sh** — quick status snapshot helper

### 2. `@memwatchdog` chat participant (`chatParticipant.js`)
Four slash commands:
| Command | Description |
|---|---|
| `/memwatchdog status` | RAM%, VS Code RSS, PSI, service state snapshot |
| `/memwatchdog logs` | Last 40 journal lines from the daemon |
| `/memwatchdog tune <profile>` | Apply balanced/conservative/playwright profile |
| `/memwatchdog act <action>` | Kill Chrome, restart service, or open dashboard |

- Followup suggestions after each command for conversation flow
- Graceful no-op when Chat API unavailable (VS Code < 1.93)
- Tuning profiles aligned with daemon v20260326.5 defaults

### Files changed
- **New**: `chatParticipant.js`, `skillInstaller.js`, `skills/mem-watchdog-ops/SKILL.md`, `skills/mem-watchdog-ops/watchdog-snapshot.sh`
- **New tests**: `chatParticipant.test.js` (20 tests), `skillInstaller.test.js` (3 tests)
- **Modified**: `extension.js` (imports + activation steps 1b and 7), `package.json` (chatParticipants + chatSkills + v0.3.8)
- **Docs**: CHANGELOG, README (ext + repo), copilot-instructions.md, ci.yml — test count 75→100

### Stale PR #32 closed
9 days stale, 6 merge conflicts. This PR reimplements cleanly from current main.

### Gate evidence
```
bash test-watchdog.sh:     18/18 ✅
bash -n mem-watchdog.sh:   clean ✅
shellcheck:                clean ✅
npm test:                  100/100 ✅
docs-integrity-check:     4/4 ✅
```

Closes #33