### PR TITLE
fix(extension): set chat participant isSticky: false to fix duplicate UI perception

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,7 +78,7 @@ EXPLORE → PLAN → IMPLEMENT → GATE → REFLECT → COMMIT
 bash test-watchdog.sh                                                          # 18 bash tests, ~3s
 bash -n mem-watchdog.sh                                                        # syntax check
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh
-cd vscode-extension && npm test                                                # 100 JS unit tests, ~1s
+cd vscode-extension && npm test                                                # 103 JS unit tests, ~1s
 bash scripts/docs-integrity-check.sh                                           # docs drift check
 ```
 
@@ -91,7 +91,7 @@ bash scripts/docs-integrity-check.sh                                           #
 ```bash
 cd vscode-extension
 npm run build              # populate resources/ for dev (gitignored; required before vsce package)
-npm test                   # 100 unit tests via node:test (~1s)
+npm test                   # 103 unit tests via node:test (~1s)
 npm run test:coverage      # + c8 V8 lcov output
 npm run test:stress        # pileup guard + event-loop lag + heap scenarios
 npx vsce package           # → mem-watchdog-status-x.y.z.vsix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@
 #
 #   bash test-watchdog.sh   # on your Crostini machine
 #
-# The CI gate covers: daemon syntax, shellcheck, all 100 JS unit tests, and docs integrity.
+# The CI gate covers: daemon syntax, shellcheck, all 103 JS unit tests, and docs integrity.
 # ──────────────────────────────────────────────────────────────────────────────
 
 name: CI
@@ -74,7 +74,7 @@ jobs:
         run: npm ci
         working-directory: vscode-extension
 
-      - name: npm test (100 unit tests)
+      - name: npm test (103 unit tests)
         run: npm test
         working-directory: vscode-extension
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: PolyForm NC](https://img.shields.io/badge/License-PolyForm%20NC%201.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-ChromeOS%20Crostini-4285f4)](https://chromeos.dev/en/linux)
 [![Tests](https://img.shields.io/badge/bash-18%2F18-brightgreen)](test-watchdog.sh)
-[![Tests](https://img.shields.io/badge/js-100%2F100-brightgreen)](vscode-extension/package.json)
+[![Tests](https://img.shields.io/badge/js-103%2F103-brightgreen)](vscode-extension/package.json)
 
 _`earlyoom` hard-crashes on Crostini (exit 104, every 3 seconds, zero protection). This replaces it with a VS Code-aware watchdog that kills Chrome before the kernel OOM-kills VS Code._
 
@@ -156,7 +156,7 @@ All 4 gates must pass before any change is published:
 
 ```bash
 bash test-watchdog.sh              # 18 bash tests (~3 s) — service, OOM scores, PSI, SwapFree safety, SIGTERM
-cd vscode-extension && npm test    # 100 JS unit tests (~1 s) — extension state machine, activation singleton, pileup guard, utils
+cd vscode-extension && npm test    # 103 JS unit tests (~1 s) — extension state machine, activation singleton, pileup guard, utils
 bash -n mem-watchdog.sh            # bash syntax check
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh
 ```

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.9] — 2026-03-26
+
+### Fixed
+- **Chat participant no longer pins to Chat panel** ([#43](https://github.com/chf3198/crostini-mem-watchdog/issues/43)) — `isSticky: true` in `package.json` caused the `@memwatchdog` chat participant to be permanently pinned in the Chat panel alongside the status bar item, creating the perception of "duplicate IDE info elements." Changed to `isSticky: false` — the participant is now invoked on demand with `@memwatchdog` rather than auto-pinned.
+
+### Tests
+- JS unit tests: 100 → **103 passing**
+- Added `chatParticipant.test.js`: 2 manifest contract tests — `isSticky: false` regression guard, runtime ID matches `package.json` declaration
+- Added `extension.activate.test.js`: 1 idempotency test — verifies exactly 1 status bar item + 1 chat participant registration across repeated `activate()` calls
+
 ## [0.3.8] — 2026-03-26
 
 ### Added

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -170,7 +170,7 @@ Commercial use requires a paid license. See [COMMERCIAL-LICENSE.md](https://gith
 git clone https://github.com/chf3198/crostini-mem-watchdog.git
 cd crostini-mem-watchdog/vscode-extension
 npm run build          # populate resources/ from repo root
-npm test               # 100 JS unit tests via node:test (zero-install)
+npm test               # 103 JS unit tests via node:test (zero-install)
 npm run test:coverage  # same + c8 V8 coverage report
 npm run test:stress    # stress scenarios: pileup guard, EL lag, heap usage
 ```

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "mem-watchdog-status",
   "displayName": "Mem Watchdog",
   "description": "Prevents VS Code from being OOM-killed on ChromeOS Crostini — auto-installs a systemd memory watchdog daemon that kills Chrome/Playwright before the kernel kills VS Code.",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "publisher": "CurtisFranks",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
@@ -139,7 +139,7 @@
         "name": "memwatchdog",
         "fullName": "Mem Watchdog Assistant",
         "description": "Inspect watchdog status and logs, and apply memory tuning profiles",
-        "isSticky": true,
+        "isSticky": false,
         "commands": [
           {
             "name": "status",

--- a/vscode-extension/test/unit/chatParticipant.test.js
+++ b/vscode-extension/test/unit/chatParticipant.test.js
@@ -244,6 +244,30 @@ describe('chatParticipant — requestHandler()', () => {
     });
 });
 
+describe('chatParticipant — manifest contract (#43 regression)', () => {
+    test('package.json chatParticipants.isSticky is false — prevents duplicate UI perception', () => {
+        // Regression guard for #43: isSticky: true caused the chat participant to
+        // be pinned permanently in the Chat panel alongside the status bar item,
+        // creating the perception of "duplicate IDE info elements."
+        const pkg = require('../../package.json');
+        const participant = pkg.contributes.chatParticipants[0];
+        assert.equal(participant.isSticky, false,
+            'isSticky must be false — true pins the chat participant in the Chat panel, ' +
+            'creating perceived duplication with the status bar item (#43)');
+    });
+
+    test('chatParticipant ID matches between package.json and runtime registration', () => {
+        const pkg = require('../../package.json');
+        const declaredId = pkg.contributes.chatParticipants[0].id;
+        const ctx = { subscriptions: [] };
+        _createdParticipants.length = 0;
+        registerChatParticipant(ctx);
+        assert.equal(_createdParticipants[0].id, declaredId,
+            'runtime createChatParticipant ID must match package.json declaration');
+        _createdParticipants.length = 0;
+    });
+});
+
 describe('chatParticipant — registerChatParticipant()', () => {
     beforeEach(() => { _createdParticipants.length = 0; });
 

--- a/vscode-extension/test/unit/extension.activate.test.js
+++ b/vscode-extension/test/unit/extension.activate.test.js
@@ -68,14 +68,35 @@ require.cache[commandsPath] = {
 };
 
 require.cache[utilsPath] = {
-    id: utilsPath,
-    filename: utilsPath,
-    loaded: true,
-    paths: [],
+    id: utilsPath, filename: utilsPath, loaded: true, paths: [],
     exports: {
         readMeminfo: () => ({ totalKB: 6440000, availableKB: 4000000, pct: 62 }),
         sh: async () => ({ ok: true, stdout: '', stderr: '' }),
         checkServiceStatus: async () => 'active',
+    },
+};
+
+// ── Mock: updateChecker ───────────────────────────────────────────────────────
+const updateCheckerPath = path.resolve(__dirname, '../../updateChecker.js');
+require.cache[updateCheckerPath] = {
+    id: updateCheckerPath, filename: updateCheckerPath, loaded: true, paths: [],
+    exports: { checkForUpdate: async () => {} },
+};
+
+// ── Mock: skillInstaller ──────────────────────────────────────────────────────
+const skillInstallerPath = path.resolve(__dirname, '../../skillInstaller.js');
+require.cache[skillInstallerPath] = {
+    id: skillInstallerPath, filename: skillInstallerPath, loaded: true, paths: [],
+    exports: { installGlobalSkill: () => ({ state: 'current' }) },
+};
+
+// ── Mock: chatParticipant — tracks registration calls (#43 regression) ────────
+const chatParticipantPath = path.resolve(__dirname, '../../chatParticipant.js');
+let registeredParticipantCount = 0;
+require.cache[chatParticipantPath] = {
+    id: chatParticipantPath, filename: chatParticipantPath, loaded: true, paths: [],
+    exports: {
+        registerChatParticipant() { registeredParticipantCount++; },
     },
 };
 
@@ -96,6 +117,7 @@ function disposeContext(context) {
 beforeEach(() => {
     createdItems = [];
     disposedItems = 0;
+    registeredParticipantCount = 0;
     ext.deactivate();
 });
 
@@ -114,4 +136,26 @@ test('activate() is idempotent in-process: second call does not create a second 
     disposeContext(contextB);
 
     assert.ok(disposedItems >= 1, 'expected created status bar item to be disposed on deactivate/disposal');
+});
+
+test('#43 regression: activate() creates exactly 1 status bar + 1 chat participant, not duplicates', async () => {
+    const context = makeContext();
+
+    await ext.activate(context);
+
+    assert.equal(createdItems.length, 1,
+        `expected exactly 1 status bar item, got ${createdItems.length}`);
+    assert.equal(registeredParticipantCount, 1,
+        `expected exactly 1 chat participant registration, got ${registeredParticipantCount}`);
+
+    // Second activate must not create any more UI elements
+    await ext.activate(context);
+
+    assert.equal(createdItems.length, 1,
+        `idempotency broken: 2nd activate() created ${createdItems.length} status bar items`);
+    assert.equal(registeredParticipantCount, 1,
+        `idempotency broken: 2nd activate() ran ${registeredParticipantCount} chat registrations`);
+
+    ext.deactivate();
+    disposeContext(context);
 });


### PR DESCRIPTION
## Summary

Fixes the "duplicate IDE info element" perception reported in #43.

### Root cause

The `@memwatchdog` chat participant was declared with `isSticky: true` in `package.json`, causing it to be permanently pinned in the Chat panel. Combined with the always-visible status bar item (RAM %), users saw two persistent Mem Watchdog surfaces showing overlapping information.

The extension code has robust idempotency guards (`_activated` flag, `disposeRuntimeUi()`, static status bar ID) — there is no actual duplication bug. The perceived "duplicate" is two intentionally different UI surfaces:
1. **Status bar item** — glanceable RAM %
2. **Chat participant** — interactive ops (`@memwatchdog status/logs/tune/act`)

### Fix

Changed `isSticky: false` in the `chatParticipants` contribution point. The chat participant now appears only when explicitly invoked with `@memwatchdog` rather than auto-pinning in the Chat panel.

### Regression tests (3 new, 100 → 103 total)

| Test file | Test | Purpose |
|-----------|------|---------|
| `chatParticipant.test.js` | manifest: isSticky is false | Prevents regression — guards against re-pinning |
| `chatParticipant.test.js` | manifest: runtime ID matches package.json | Ensures contribution + runtime are linked |
| `extension.activate.test.js` | #43: exactly 1 status bar + 1 chat participant | Full activation idempotency |

### Gate suite results

| Gate | Result |
|------|--------|
| `bash test-watchdog.sh` | 18/18 PASS |
| `bash -n mem-watchdog.sh` | OK |
| `shellcheck` | OK |
| `npm test` | 103/103 PASS |
| `docs-integrity-check.sh` | 4/4 PASS |

Bumps extension to v0.3.9.

Closes #43