### PR TITLE
docs: sync README thresholds and architecture with daemon v20260326.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ This watchdog reads only `MemAvailable` and `MemTotal` — both correct on this 
 | `MemAvailable ≤ 15%`   | `SIGKILL` Chrome / Playwright                                                                    |
 | `MemAvailable ≤ 25%`   | `SIGTERM` Chrome / Playwright                                                                    |
 | PSI `full avg10 > 25%` | `SIGTERM` Chrome (sustained memory stall)                                                        |
-| VS Code RSS > 3.0 GB   | `SIGTERM` Chrome + desktop notification; if no Chrome → log and defer to EMERGENCY               |
-| VS Code RSS > 3.2 GB   | `SIGKILL` Chrome; if no Chrome → `SIGTERM` highest-RSS extension host to save the VS Code window |
+| VS Code RSS > 3.4 GB   | `SIGTERM` Chrome + desktop notification; if no Chrome → log and defer to EMERGENCY               |
+| VS Code RSS > 3.8 GB   | `SIGKILL` Chrome; if no Chrome → `SIGTERM` highest-RSS extension host to save the VS Code window |
 | RSS velocity spike     | Kill lowest-value VS Code helper — **never** a language server or Extension Host at normal severity |
 | Every loop             | Set `oom_score_adj=0` on VS Code PIDs (counters Electron's 200–300 default)                      |
 | Every loop             | Set `oom_score_adj=1000` on Chrome PIDs (kernel kills it first)                                  |
 
-**Language-server protection:** Built-in language servers (HTML, JSON, CSS, Markdown, ESLint) and the Extension Host process are excluded from the helper-kill candidate pool at normal severity. These 80–120 MB processes are subject to VS Code's 5-crash-in-3-minutes permanent death threshold — killing them saves <2% of memory for 2 seconds (they respawn immediately) while permanently disabling language intelligence until a full VS Code restart. Only at true emergency severity (RSS ≥ 3.2 GB) are they considered as last-resort targets.
+**Language-server protection:** Built-in language servers (HTML, JSON, CSS, Markdown, ESLint) and the Extension Host process are excluded from the helper-kill candidate pool at normal severity. These 80–120 MB processes are subject to VS Code's 5-crash-in-3-minutes permanent death threshold — killing them saves <2% of memory for 2 seconds (they respawn immediately) while permanently disabling language intelligence until a full VS Code restart. Only at true emergency severity (RSS ≥ 3.8 GB) are they considered as last-resort targets.
 
 - Checks every **2 seconds** (4s was confirmed too slow — missed a 4 GB spike in < 4s on 2026-03-05)
 - **Startup mode**: 0.5 s polling for 90 s after new VS Code PIDs detected — catches extension-host spikes during startup
@@ -106,10 +106,13 @@ crostini-mem-watchdog/
 ├── test-pressure.sh             ← live memory pressure tests
 ├── watchdog-tray.sh             ← optional: yad system tray icon
 └── vscode-extension/            ← VS Code extension (primary install path)
-    ├── extension.js             ← activate(): install → config → commands → status bar
-    ├── installer.js             ← SHA-256 hash-based auto-install/upgrade
+    ├── extension.js             ← activate(): install → skill → config → commands → status bar → update check → chat
+    ├── installer.js             ← SHA-256 hash-based auto-install/upgrade + MIN_SAFE guard
     ├── configWriter.js          ← VS Code Settings → ~/.config/mem-watchdog/config.sh
     ├── commands.js              ← dashboard, preflight, killChrome, restartService
+    ├── updateChecker.js         ← GitHub Releases API self-update check (24h throttled)
+    ├── skillInstaller.js        ← installs/updates ~/.copilot/skills/mem-watchdog-ops/
+    ├── chatParticipant.js       ← @memwatchdog chat participant: /status, /logs, /tune, /act
     ├── utils.js                 ← readMeminfo(), readPsi(), sh(), checkServiceStatus() — shared helpers
     ├── lifecycle.js             ← vscode:uninstall: stop + disable service
     └── scripts/prepare.js       ← vscode:prepublish: bundles daemon files into resources/
@@ -135,8 +138,8 @@ crostini-mem-watchdog/
 | `INTERVAL`            | `2`       | Seconds between normal checks                          |
 | `STARTUP_INTERVAL`    | `0.5`     | Seconds between checks in startup mode                 |
 | `STARTUP_DURATION`    | `90`      | Seconds to stay in startup mode after new VS Code PIDs |
-| `VSCODE_RSS_WARN_KB`  | `3000000` | ~3.0 GB — VS Code RSS warning level                    |
-| `VSCODE_RSS_EMERG_KB` | `3200000` | ~3.2 GB — VS Code RSS emergency level                  |
+| `VSCODE_RSS_WARN_KB`  | `3400000` | ~3.4 GB — VS Code RSS warning level                    |
+| `VSCODE_RSS_EMERG_KB` | `3800000` | ~3.8 GB — VS Code RSS emergency level                  |
 | `NOTIFY_INTERVAL`     | `300`     | Seconds between desktop notifications per severity     |
 
 ### Tuning for Your RAM
@@ -144,7 +147,7 @@ crostini-mem-watchdog/
 | Total RAM        | `VSCODE_RSS_WARN_KB` | `VSCODE_RSS_EMERG_KB` |
 | ---------------- | -------------------- | --------------------- |
 | 4 GB             | `1500000`            | `2000000`             |
-| 6 GB _(default)_ | `3000000`            | `3200000`             |
+| 6 GB _(default)_ | `3400000`            | `3800000`             |
 | 8 GB             | `3500000`            | `5000000`             |
 | 16 GB            | `6000000`            | `10000000`            |
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -15,13 +15,13 @@ The daemon acts on these conditions (checked every 2 seconds):
 | `MemAvailable ≤ 15%` (~945 MB on 6 GB) | `SIGKILL` Chrome / Playwright |
 | `MemAvailable ≤ 25%` (~1.6 GB on 6 GB) | `SIGTERM` Chrome / Playwright |
 | PSI `full avg10 > 25%` | `SIGTERM` Chrome (sustained memory stall) |
-| VS Code RSS > 3.0 GB | `SIGTERM` Chrome + desktop notification; if no Chrome → log and defer to EMERGENCY |
-| VS Code RSS > 3.5 GB | `SIGKILL` Chrome; if no Chrome → `SIGTERM` the highest-RSS extension host process to save the VS Code window |
+| VS Code RSS > 3.4 GB | `SIGTERM` Chrome + desktop notification; if no Chrome → log and defer to EMERGENCY |
+| VS Code RSS > 3.8 GB | `SIGKILL` Chrome; if no Chrome → `SIGTERM` the highest-RSS extension host process to save the VS Code window |
 | RSS velocity spike | Kill lowest-value VS Code helper — **never** a language server or Extension Host at normal severity |
 
-**Language-server protection:** Built-in language servers (HTML, JSON, CSS, Markdown, ESLint) and the Extension Host process (hosting Copilot, Playwright MCP, and all extensions) are excluded from the helper-kill candidate pool at normal severity. These small processes (80–120 MB) are subject to VS Code's 5-crash-in-3-minutes permanent death threshold — killing one saves negligible memory while permanently disabling language intelligence or all extensions. They are only considered as last-resort targets at true emergency severity (RSS ≥ 3.5 GB).
+**Language-server protection:** Built-in language servers (HTML, JSON, CSS, Markdown, ESLint) and the Extension Host process (hosting Copilot, Playwright MCP, and all extensions) are excluded from the helper-kill candidate pool at normal severity. These small processes (80–120 MB) are subject to VS Code's 5-crash-in-3-minutes permanent death threshold — killing one saves negligible memory while permanently disabling language intelligence or all extensions. They are only considered as last-resort targets at true emergency severity (RSS ≥ 3.8 GB).
 
-**Startup mode:** when new VS Code PIDs appear, the daemon switches to **0.5 s polling for 90 s** and drops the RSS emergency threshold to 3.4 GB — catching the extension-host spike that caused the crash this tool was built to prevent (0 → 4 GB RSS in under 2 seconds during startup).
+**Startup mode:** when new VS Code PIDs appear, the daemon switches to **0.5 s polling for 90 s** and raises the RSS emergency threshold to 4.0 GB — catching the extension-host spike that caused the crash this tool was built to prevent (0 → 4 GB RSS in under 2 seconds during startup).
 
 ---
 
@@ -91,7 +91,7 @@ Configure all thresholds via **VS Code Settings → Mem Watchdog**. Changes take
 | System RAM | `vscodeRssWarnMB` | `vscodeRssEmergencyMB` |
 |---|---|---|
 | 4 GB | `1500` | `2000` |
-| 6 GB *(default)* | `3000` | `3500` |
+| 6 GB *(default)* | `3400` | `3800` |
 | 8 GB | `3500` | `5000` |
 | 16 GB | `6000` | `10000` |
 
@@ -107,9 +107,11 @@ VS Code Extension (this)            Systemd Daemon (independent process)
 • Auto-installs daemon         →    ~/.local/bin/mem-watchdog.sh
 • Writes config on change      →    ~/.config/mem-watchdog/config.sh
 • Status bar + 4 commands           • Polls /proc/meminfo + PSI every 2 s
-• Upgrade detection via hash        • Kills Chrome on threshold breach
-• Settings → config sync            • Survives VS Code freezing / crashing
-• OOM-resilient service monitoring  • oom_score_adj tuning every loop
+• @memwatchdog chat participant     • Kills Chrome on threshold breach
+• GitHub Releases update checker    • Survives VS Code freezing / crashing
+• Copilot skill installer           • oom_score_adj tuning every loop
+• Upgrade detection via hash        • Config sourcing (no script modification)
+• OOM-resilient service monitoring  • Language-server + ExtHost protection
 ```
 
 ---
@@ -143,7 +145,7 @@ cd vscode-extension
 npm run build
 npm install -g @vscode/vsce
 vsce package
-code --install-extension mem-watchdog-status-0.3.8.vsix
+code --install-extension mem-watchdog-status-*.vsix
 ```
 
 Reload the window (`Developer: Reload Window`). The daemon installs and starts automatically on first activation.
@@ -175,4 +177,4 @@ npm run test:coverage  # same + c8 V8 coverage report
 npm run test:stress    # stress scenarios: pileup guard, EL lag, heap usage
 ```
 
-100 unit tests covering `readMeminfo`/`readPsi`/`sh()`/`checkServiceStatus()`, config validation, command handlers, installer decision logic, `activate()` singleton lifecycle, the `update()` state machine + pileup guard, update checker (version comparison, throttling, dismissal), installer MIN_SAFE_DAEMON_VERSION guard, skill installer (install/update/skip), and `@memwatchdog` chat participant (all 4 commands, profile detection/application, followups, API availability guard).
+103 unit tests covering `readMeminfo`/`readPsi`/`sh()`/`checkServiceStatus()`, config validation, command handlers, installer decision logic, `activate()` singleton lifecycle, the `update()` state machine + pileup guard, update checker (version comparison, throttling, dismissal), installer MIN_SAFE_DAEMON_VERSION guard, skill installer (install/update/skip), and `@memwatchdog` chat participant (all 4 commands, profile detection/application, followups, API availability guard).


### PR DESCRIPTION
## Summary

Sync both READMEs with the current daemon defaults and extension module inventory.

### Drift points fixed

| File | Issue | Old | New |
|---|---|---|---|
| README.md | `What It Does` table WARN threshold | 3.0 GB | 3.4 GB |
| README.md | `What It Does` table EMERG threshold | 3.2 GB | 3.8 GB |
| README.md | Language-server protection threshold | 3.2 GB | 3.8 GB |
| README.md | Configuration table defaults | 3000000 / 3200000 | 3400000 / 3800000 |
| README.md | Tuning table 6 GB row | 3000000 / 3200000 | 3400000 / 3800000 |
| README.md | Architecture tree | missing 3 modules | +updateChecker, skillInstaller, chatParticipant |
| extension/README.md | Kill Hierarchy table WARN | 3.0 GB | 3.4 GB |
| extension/README.md | Kill Hierarchy table EMERG | 3.5 GB | 3.8 GB |
| extension/README.md | Language-server protection | 3.5 GB | 3.8 GB |
| extension/README.md | Startup mode EMERG | 3.4 GB | 4.0 GB |
| extension/README.md | RAM Tuning Guide 6 GB row | 3000 / 3500 | 3400 / 3800 |
| extension/README.md | Architecture diagram | 6 lines | 8 lines |
| extension/README.md | Install vsix filename | hardcoded 0.3.8 | glob pattern |
| extension/README.md | Test count paragraph | 100 | 103 |

### Gate evidence
- 18/18 bash tests
- bash -n OK
- shellcheck OK
- 103/103 JS tests
- docs-integrity 4/4

Pre-release docs sync — no code changes.