### PR TITLE
docs(policy): sync community health files with actual test counts and gate suite

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@ the non-negotiable invariants, and how to run the gate suite before opening a PR
 git clone https://github.com/chf3198/crostini-mem-watchdog.git
 cd crostini-mem-watchdog/vscode-extension
 npm ci           # install devDependencies (no prod deps)
-npm test         # 54 unit tests — must exit 0
+npm test         # 103 unit tests — must exit 0
 ```
 
 > **Important:** `npm test` must be run from inside `vscode-extension/`, not from
@@ -32,7 +32,7 @@ EXPLORE → PLAN → IMPLEMENT → GATE → REFLECT → COMMIT
   if the change touches more than 2 files.
 - **IMPLEMENT**: Make the change. After every edit to a shell file, run
   `bash -n <file>` immediately.
-- **GATE**: All four checks must exit 0 — no exceptions, no skips.
+- **GATE**: All five checks must exit 0 — no exceptions, no skips.
 - **REFLECT**: Read your own diff. Ask: _"What did I not test? What could break
   under OOM pressure or during VS Code startup?"_ Fix those gaps.
 - **COMMIT**: One logical change per commit (see format below).
@@ -41,10 +41,10 @@ EXPLORE → PLAN → IMPLEMENT → GATE → REFLECT → COMMIT
 
 ## Gate Suite
 
-Run all four checks before every commit. All must exit 0.
+Run all five checks before every commit. All must exit 0.
 
 ```bash
-# 1. Bash unit tests (12 tests, ~3 s) — run from repo root
+# 1. Bash unit tests (18 tests, ~3 s) — run from repo root
 bash test-watchdog.sh
 
 # 2. Bash syntax check
@@ -53,8 +53,11 @@ bash -n mem-watchdog.sh
 # 3. ShellCheck — SC1091 (source) and SC2317 (unreachable) are intentionally suppressed
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh
 
-# 4. JS unit tests (54 tests, ~1 s) — must run from vscode-extension/
+# 4. JS unit tests (103 tests, ~1 s) — must run from vscode-extension/
 cd vscode-extension && npm test
+
+# 5. Documentation drift check
+bash scripts/docs-integrity-check.sh
 ```
 
 For performance regression checking (optional but encouraged):
@@ -142,14 +145,21 @@ known failure modes.
 ```
 mem-watchdog.sh          ← core daemon; single infinite loop, no deps beyond coreutils
 mem-watchdog.service     ← systemd user unit (systemctl --user, NOT system)
-install.sh               ← installer: copies daemon to ~/.local/bin/, enables service
-test-watchdog.sh         ← 12-test suite; exits 0/1; logs to scratch/
-vscode-extension/        ← self-contained VS Code extension
-  extension.js           ← activate(): orchestrates install, config, commands, status bar
-  installer.js           ← hash-based daemon auto-install/upgrade
-  configWriter.js        ← VS Code settings → ~/.config/mem-watchdog/config.sh
-  commands.js            ← dashboard, preflight, killChrome, restartService commands
+install.sh               ← shell-only installer (no VS Code required)
+test-watchdog.sh         ← 18-test suite; exits 0/1; logs to scratch/
+vscode-extension/
+  extension.js           ← activate(): install → skill → config → commands → status bar (2s poll) → update check → chat
+  installer.js           ← SHA-256 hash-based daemon auto-install/upgrade + MIN_SAFE guard
+  configWriter.js        ← VS Code Settings → ~/.config/mem-watchdog/config.sh
+  commands.js            ← 4 commands: dashboard, preflight, killChrome, restartService
+  updateChecker.js       ← GitHub Releases API self-update check (24h throttled, non-blocking)
+  skillInstaller.js      ← installs/updates ~/.copilot/skills/mem-watchdog-ops/ on activation
+  chatParticipant.js     ← @memwatchdog chat participant: /status, /logs, /tune, /act
+  utils.js               ← readMeminfo(), sh(), checkServiceStatus() — shared helpers
   lifecycle.js           ← vscode:uninstall hook; stops + disables the service
+  scripts/prepare.js     ← vscode:prepublish: copies daemon files → resources/
+  skills/mem-watchdog-ops/ ← bundled Copilot skill (SKILL.md + watchdog-snapshot.sh)
+  resources/             ← BUILD ARTIFACT (gitignored); bundled into .vsix by vsce
   test/                  ← unit tests (node:test, no framework dep)
   test/bench/            ← micro-benchmarks (run manually, not in CI)
 ```
@@ -168,7 +178,7 @@ detection trivial.
 # Test without killing anything
 ./mem-watchdog.sh --dry-run
 
-# Run all 12 validation tests (~3 s, exits 0/1) — logs go to scratch/
+# Run all 18 validation tests (~3 s, exits 0/1) — logs go to scratch/
 bash test-watchdog.sh
 
 # Service management
@@ -179,7 +189,7 @@ journalctl --user -u mem-watchdog -f
 # Build and publish VS Code extension
 cd vscode-extension
 npm run build                     # populate resources/ for local dev/testing
-npm test                          # 54 JS unit tests
+npm test                          # 103 JS unit tests
 npm run test:coverage             # + c8 V8 coverage report
 npm run test:stress               # stress scenarios
 npx vsce package                  # → mem-watchdog-status-x.y.z.vsix
@@ -192,7 +202,7 @@ npx vsce package                  # → mem-watchdog-status-x.y.z.vsix
 1. Fork the repository.
 2. Create a branch: `type/short-description` (e.g., `fix/daemon-psi-threshold`).
 3. Make your change following the workflow above.
-4. Run the full gate suite. All four checks must exit 0.
+4. Run the full gate suite. All five checks must exit 0.
 5. Open a PR against `main`. The PR template checklist will guide you through
    the remaining steps.
 6. Before release/publish, obtain explicit client UAT pass confirmation.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,12 +23,13 @@ Closes #
 
 ## Gate suite results
 
-All four checks must exit 0 before this PR is ready for review.
+All five checks must exit 0 before this PR is ready for review.
 
-- [ ] `bash test-watchdog.sh` — 12 bash tests (run from repo root)
+- [ ] `bash test-watchdog.sh` — 18 bash tests (run from repo root)
 - [ ] `bash -n mem-watchdog.sh` — bash syntax check
 - [ ] `shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh`
-- [ ] `cd vscode-extension && npm test` — 54 JS unit tests
+- [ ] `cd vscode-extension && npm test` — 103 JS unit tests
+- [ ] `bash scripts/docs-integrity-check.sh` — documentation drift check
 
 ## Invariants confirmed
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -113,7 +113,7 @@ The following GitHub-native security tooling is configured or available for this
 
 | Feature | Config file | What it does |
 |---|---|---|
-| **CI gate** | `.github/workflows/ci.yml` | Runs shellcheck + 54 unit tests on every PR |
+| **CI gate** | `.github/workflows/ci.yml` | Runs shellcheck, 18 bash tests, 103 JS unit tests, and docs-integrity check on every PR |
 | **Dependency Review** | `.github/workflows/ci.yml` (job: `dependency-review`) | Blocks PRs that introduce deps with CVEs ≥ moderate severity |
 | **Dependabot version updates** | `.github/dependabot.yml` | Weekly PRs to keep `npm` devDeps and GitHub Actions current |
 | **Least-privilege Actions** | Both workflow files | `permissions: contents: read` globally; jobs override only what they need |
@@ -133,7 +133,7 @@ Navigate to **Settings → Branches → Add branch protection rule** for `main`:
 | Setting | Value | Why |
 |---|---|---|
 | Require a pull request before merging | ✅ | Ensures CI runs before anything reaches main |
-| Require status checks to pass | ✅ `CI / Daemon`, `CI / Extension (18/20/22)` | Gate suite must be green |
+| Require status checks to pass | ✅ `Daemon — bash -n + shellcheck`, `Extension — node:test (Node 20)`, `Docs integrity check`, `Secret scan — gitleaks` | Gate suite must be green |
 | Require branches to be up to date | ✅ | Prevents merging on stale base |
 | Do not allow bypassing the above settings | ✅ | Applies to administrators too |
 | Allow force pushes | ❌ | Prevents history rewriting on main |


### PR DESCRIPTION
## What does this PR do?

Fixes 14 stale references across 3 community health files to match the source of truth (`.github/copilot-instructions.md`).

## Closes

Closes #93

## Tracking

- [x] Milestone assigned
- [x] Labels applied: `type: bug-fix` + `priority: high` + `policy`
- [x] Commit messages follow `type(scope): description` convention
- [x] Client UAT requirement acknowledged: docs-only change, no behavioral impact

## Motivation

CONTRIBUTING.md, PULL_REQUEST_TEMPLATE.md, and SECURITY.md drifted from reality as the test suite grew (54→103 JS, 12→18 bash) and the 5th gate check (docs-integrity-check.sh) was added. Contributors see stale counts in PR templates. SECURITY.md listed incorrect CI check names.

## Gate suite results

All five checks exit 0.

- [x] `bash test-watchdog.sh` — 18 bash tests (18/18 PASS)
- [x] `bash -n mem-watchdog.sh` — syntax check
- [x] `shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh`
- [x] `cd vscode-extension && npm test` — 103 JS unit tests (103 pass, 0 fail)
- [x] `bash scripts/docs-integrity-check.sh` — 4/4 passed

## Invariants confirmed

- [x] No code changes — docs only
- [x] `SwapFree` is not read anywhere in this diff
- [x] `systemctl --user` not affected

## What I did NOT test

This is a docs-only change. No code, no daemon, no extension behavior changed.

## Critique

Verified every stale reference with `grep -E '54 unit|54 test|12 bash|12-test|four check' ` across the entire repo — only the historical CHANGELOG entry remains (correct, it was accurate at the time).