### PR TITLE
fix(extension): write config before daemon restart on activate

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@ the non-negotiable invariants, and how to run the gate suite before opening a PR
 git clone https://github.com/chf3198/crostini-mem-watchdog.git
 cd crostini-mem-watchdog/vscode-extension
 npm ci           # install devDependencies (no prod deps)
-npm test         # 103 unit tests — must exit 0
+npm test         # 105 unit tests — must exit 0
 ```
 
 > **Important:** `npm test` must be run from inside `vscode-extension/`, not from
@@ -53,7 +53,7 @@ bash -n mem-watchdog.sh
 # 3. ShellCheck — SC1091 (source) and SC2317 (unreachable) are intentionally suppressed
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh
 
-# 4. JS unit tests (103 tests, ~1 s) — must run from vscode-extension/
+# 4. JS unit tests (105 tests, ~1 s) — must run from vscode-extension/
 cd vscode-extension && npm test
 
 # 5. Documentation drift check
@@ -189,7 +189,7 @@ journalctl --user -u mem-watchdog -f
 # Build and publish VS Code extension
 cd vscode-extension
 npm run build                     # populate resources/ for local dev/testing
-npm test                          # 103 JS unit tests
+npm test                          # 105 JS unit tests
 npm run test:coverage             # + c8 V8 coverage report
 npm run test:stress               # stress scenarios
 npx vsce package                  # → mem-watchdog-status-x.y.z.vsix

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@ All five checks must exit 0 before this PR is ready for review.
 - [ ] `bash test-watchdog.sh` — 18 bash tests (run from repo root)
 - [ ] `bash -n mem-watchdog.sh` — bash syntax check
 - [ ] `shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh`
-- [ ] `cd vscode-extension && npm test` — 103 JS unit tests
+- [ ] `cd vscode-extension && npm test` — 105 JS unit tests
 - [ ] `bash scripts/docs-integrity-check.sh` — documentation drift check
 
 ## Invariants confirmed

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -113,7 +113,7 @@ The following GitHub-native security tooling is configured or available for this
 
 | Feature | Config file | What it does |
 |---|---|---|
-| **CI gate** | `.github/workflows/ci.yml` | Runs shellcheck, 18 bash tests, 103 JS unit tests, and docs-integrity check on every PR |
+| **CI gate** | `.github/workflows/ci.yml` | Runs shellcheck, 18 bash tests, 105 JS unit tests, and docs-integrity check on every PR |
 | **Dependency Review** | `.github/workflows/ci.yml` (job: `dependency-review`) | Blocks PRs that introduce deps with CVEs ≥ moderate severity |
 | **Dependabot version updates** | `.github/dependabot.yml` | Weekly PRs to keep `npm` devDeps and GitHub Actions current |
 | **Least-privilege Actions** | Both workflow files | `permissions: contents: read` globally; jobs override only what they need |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,7 +78,7 @@ EXPLORE → PLAN → IMPLEMENT → GATE → REFLECT → COMMIT
 bash test-watchdog.sh                                                          # 18 bash tests, ~3s
 bash -n mem-watchdog.sh                                                        # syntax check
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh
-cd vscode-extension && npm test                                                # 103 JS unit tests, ~1s
+cd vscode-extension && npm test                                                # 105 JS unit tests, ~1s
 bash scripts/docs-integrity-check.sh                                           # docs drift check
 ```
 
@@ -91,7 +91,7 @@ bash scripts/docs-integrity-check.sh                                           #
 ```bash
 cd vscode-extension
 npm run build              # populate resources/ for dev (gitignored; required before vsce package)
-npm test                   # 103 unit tests via node:test (~1s)
+npm test                   # 105 unit tests via node:test (~1s)
 npm run test:coverage      # + c8 V8 lcov output
 npm run test:stress        # pileup guard + event-loop lag + heap scenarios
 npx vsce package           # → mem-watchdog-status-x.y.z.vsix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@
 #
 #   bash test-watchdog.sh   # on your Crostini machine
 #
-# The CI gate covers: daemon syntax, shellcheck, all 103 JS unit tests, and docs integrity.
+# The CI gate covers: daemon syntax, shellcheck, all 105 JS unit tests, and docs integrity.
 # ──────────────────────────────────────────────────────────────────────────────
 
 name: CI
@@ -74,7 +74,7 @@ jobs:
         run: npm ci
         working-directory: vscode-extension
 
-      - name: npm test (103 unit tests)
+      - name: npm test (105 unit tests)
         run: npm test
         working-directory: vscode-extension
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: PolyForm NC](https://img.shields.io/badge/License-PolyForm%20NC%201.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-ChromeOS%20Crostini-4285f4)](https://chromeos.dev/en/linux)
 [![Tests](https://img.shields.io/badge/bash-18%2F18-brightgreen)](test-watchdog.sh)
-[![Tests](https://img.shields.io/badge/js-103%2F103-brightgreen)](vscode-extension/package.json)
+[![Tests](https://img.shields.io/badge/js-105%2F105-brightgreen)](vscode-extension/package.json)
 
 _`earlyoom` hard-crashes on Crostini (exit 104, every 3 seconds, zero protection). This replaces it with a VS Code-aware watchdog that kills Chrome before the kernel OOM-kills VS Code._
 
@@ -159,7 +159,7 @@ All 4 gates must pass before any change is published:
 
 ```bash
 bash test-watchdog.sh              # 18 bash tests (~3 s) — service, OOM scores, PSI, SwapFree safety, SIGTERM
-cd vscode-extension && npm test    # 103 JS unit tests (~1 s) — extension state machine, activation singleton, pileup guard, utils
+cd vscode-extension && npm test    # 105 JS unit tests (~1 s) — extension state machine, activation singleton, pileup guard, utils
 bash -n mem-watchdog.sh            # bash syntax check
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh
 ```

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.3.11] — 2026-03-27
+
+### Fixed
+- **Config-before-restart activation order** ([#95](https://github.com/chf3198/crostini-mem-watchdog/issues/95)) — `activate()` wrote the config file AFTER the daemon restart, causing the daemon to load stale thresholds from the previous session. The daemon ran with WARN=3.0 GB / EMERG=3.4 GB instead of the configured WARN=3.4 GB / EMERG=3.8 GB, leading to a premature `kill_vscode_main` at 3.6 GB. Config is now written BEFORE install/restart, and a config-change-triggered restart ensures the daemon always picks up fresh values.
+- **Config change detection** — `writeConfig()` now compares existing file content before writing. Returns `{ warnings, changed }` instead of plain warnings array. Skips unnecessary writes when content is identical; triggers daemon restart only when config actually changed.
+
+### Tests
+- JS unit tests: 103 → **105 passing** (+2 new `changed`-flag tests for `writeConfig`)
+
 ## [0.3.10] — 2026-03-27
 
 ### Fixed

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -172,9 +172,9 @@ Commercial use requires a paid license. See [COMMERCIAL-LICENSE.md](https://gith
 git clone https://github.com/chf3198/crostini-mem-watchdog.git
 cd crostini-mem-watchdog/vscode-extension
 npm run build          # populate resources/ from repo root
-npm test               # 103 JS unit tests via node:test (zero-install)
+npm test               # 105 JS unit tests via node:test (zero-install)
 npm run test:coverage  # same + c8 V8 coverage report
 npm run test:stress    # stress scenarios: pileup guard, EL lag, heap usage
 ```
 
-103 unit tests covering `readMeminfo`/`readPsi`/`sh()`/`checkServiceStatus()`, config validation, command handlers, installer decision logic, `activate()` singleton lifecycle, the `update()` state machine + pileup guard, update checker (version comparison, throttling, dismissal), installer MIN_SAFE_DAEMON_VERSION guard, skill installer (install/update/skip), and `@memwatchdog` chat participant (all 4 commands, profile detection/application, followups, API availability guard).
+105 unit tests covering `readMeminfo`/`readPsi`/`sh()`/`checkServiceStatus()`, config validation, command handlers, installer decision logic, `activate()` singleton lifecycle, the `update()` state machine + pileup guard, update checker (version comparison, throttling, dismissal), installer MIN_SAFE_DAEMON_VERSION guard, skill installer (install/update/skip), and `@memwatchdog` chat participant (all 4 commands, profile detection/application, followups, API availability guard).

--- a/vscode-extension/configWriter.js
+++ b/vscode-extension/configWriter.js
@@ -83,9 +83,25 @@ function writeConfig(cfg) {
         `VSCODE_RSS_EMERG_KB=${emergKB}`,
     ];
 
-    fs.mkdirSync(CONFIG_DIR, { recursive: true });
-    fs.writeFileSync(CONFIG_FILE, lines.join('\n') + '\n', { encoding: 'utf8', mode: 0o644 });
-    return warnings; // empty array = all values valid
+    const newContent = lines.join('\n') + '\n';
+
+    // Detect whether the config file actually changed.  If the on-disk content
+    // is identical, skip the write and report changed=false so the caller can
+    // avoid an unnecessary daemon restart.
+    let changed = true;
+    try {
+        const existing = fs.readFileSync(CONFIG_FILE, 'utf8');
+        if (existing === newContent) { changed = false; }
+    } catch {
+        // File missing or unreadable → will be (re-)created below.
+    }
+
+    if (changed) {
+        fs.mkdirSync(CONFIG_DIR, { recursive: true });
+        fs.writeFileSync(CONFIG_FILE, newContent, { encoding: 'utf8', mode: 0o644 });
+    }
+
+    return { warnings, changed };
 }
 
 module.exports = { writeConfig, CONFIG_FILE };

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -1,9 +1,12 @@
 // extension.js — Mem Watchdog VS Code extension entry point
 // ─────────────────────────────────────────────────────────────────────────────
 // On activation:
-//   1. Installs / upgrades the daemon (installer.js)
-//   1b. Install / refresh user-level Copilot skill (skillInstaller.js)
-//   2. Writes VS Code settings → ~/.config/mem-watchdog/config.sh (configWriter.js)
+//   1. Writes VS Code settings → ~/.config/mem-watchdog/config.sh (configWriter.js)
+//      MUST run before install — the daemon sources this file at startup.
+//   2. Installs / upgrades the daemon (installer.js)
+//      If the config changed and the daemon was already current (no hash-based
+//      restart), forces a daemon restart to pick up the new config.
+//   2b. Install / refresh user-level Copilot skill (skillInstaller.js)
 //   3. Registers 4 commands (commands.js)
 //   4. Watches for settings changes → rewrites config + restarts daemon
 //   5. Runs the status bar status poller every 2 s (original logic preserved)
@@ -152,20 +155,47 @@ async function activate(context) {
     }
     _activated = true;
 
-    // ── 1. Install / upgrade the daemon ──────────────────────────────────────
+    // ── 1. Sync VS Code settings → config file ────────────────────────────────
+    // MUST run before install/upgrade: the daemon sources this file at startup.
+    // If the config file is written AFTER the daemon restarts, it runs with the
+    // PREVIOUS session's stale values (crash confirmed 2026-03-27, issue #95).
+    let configChanged = false;
+    try {
+        const cfgResult = configWriter.writeConfig(vscode.workspace.getConfiguration('memWatchdog'));
+        configChanged = cfgResult.changed;
+        if (cfgResult.warnings && cfgResult.warnings.length > 0) {
+            vscode.window.showWarningMessage(
+                'Mem Watchdog: invalid settings corrected to safe defaults — check Developer Console for details.'
+            );
+        }
+    } catch (err) {
+        // Non-fatal; daemon falls back to its built-in defaults
+        console.error('[memWatchdog] configWriter error:', err.message);
+    }
+
+    // ── 2. Install / upgrade the daemon ──────────────────────────────────────
     try {
         const outcome = await installer.installOrUpgrade(context);
         if (outcome === 'installed') {
             vscode.window.showInformationMessage('Mem Watchdog: daemon installed and service started ✓');
         } else if (outcome === 'upgraded') {
             vscode.window.showInformationMessage('Mem Watchdog: daemon upgraded and service restarted ✓');
+        } else if (outcome === 'current' && configChanged) {
+            // Daemon file unchanged but config file was updated — restart so
+            // the daemon re-sources the fresh config.  Without this, the daemon
+            // runs with whatever config it loaded at its last start, which may
+            // be from a previous extension version with different defaults.
+            const { ok, stderr } = await sh('systemctl --user restart mem-watchdog');
+            if (!ok) {
+                console.error('[memWatchdog] config-triggered restart failed:', stderr);
+            }
         }
-        // 'current' → no notification; service is already running correctly
+        // 'current' + !configChanged → no notification; service is running correctly
     } catch (err) {
         vscode.window.showErrorMessage(`Mem Watchdog: install failed — ${err.message}`);
     }
 
-    // ── 1b. Install / refresh user-level Copilot skill ─────────────────────
+    // ── 2b. Install / refresh user-level Copilot skill ─────────────────────
     // Installs to ~/.copilot/skills/mem-watchdog-ops so the assistant can
     // carry watchdog-specific operational context across repositories.
     try {
@@ -175,19 +205,6 @@ async function activate(context) {
         }
     } catch (err) {
         console.error('[memWatchdog] skillInstaller error:', err.message);
-    }
-
-    // ── 2. Sync VS Code settings → config file ────────────────────────────────
-    try {
-        const cfgWarnings = configWriter.writeConfig(vscode.workspace.getConfiguration('memWatchdog'));
-        if (cfgWarnings && cfgWarnings.length > 0) {
-            vscode.window.showWarningMessage(
-                'Mem Watchdog: invalid settings corrected to safe defaults — check Developer Console for details.'
-            );
-        }
-    } catch (err) {
-        // Non-fatal; daemon falls back to its built-in defaults
-        console.error('[memWatchdog] configWriter error:', err.message);
     }
 
     // ── 3. Register commands ──────────────────────────────────────────────────
@@ -205,7 +222,8 @@ async function activate(context) {
             if (!e.affectsConfiguration('memWatchdog')) { return; }
             let cfgWarnings = [];
             try {
-                cfgWarnings = configWriter.writeConfig(vscode.workspace.getConfiguration('memWatchdog')) || [];
+                const cfgResult = configWriter.writeConfig(vscode.workspace.getConfiguration('memWatchdog'));
+                cfgWarnings = cfgResult.warnings || [];
             } catch (err) {
                 console.error('[memWatchdog] configWriter update error:', err.message);
             }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "mem-watchdog-status",
   "displayName": "Mem Watchdog",
   "description": "Prevents VS Code from being OOM-killed on ChromeOS Crostini — auto-installs a systemd memory watchdog daemon that kills Chrome/Playwright before the kernel kills VS Code.",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "publisher": "CurtisFranks",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {

--- a/vscode-extension/test/unit/configWriter.test.js
+++ b/vscode-extension/test/unit/configWriter.test.js
@@ -32,9 +32,13 @@ function makeCfg(overrides = {}) {
 
 // ── Content capture helper ────────────────────────────────────────────────────
 // Each test sets this up via t.mock.method to capture what writeFileSync receives.
+// Also mocks readFileSync to simulate a missing config file (so changed=true and
+// writeFileSync is always invoked).  Tests that need to verify the `changed` flag
+// with an existing file should mock readFileSync explicitly after calling this.
 function captureWrite(t) {
     let captured = '';
     t.mock.method(fs, 'mkdirSync', () => {});
+    t.mock.method(fs, 'readFileSync', () => { throw new Error('ENOENT: simulated missing file'); });
     t.mock.method(fs, 'writeFileSync', (_path, content) => { captured = content; });
     return { get: () => captured };
 }
@@ -44,7 +48,7 @@ function captureWrite(t) {
 describe('writeConfig — kill-threshold cross-field validation', () => {
     test('valid thresholds: no warnings, correct values written', (t) => {
         const out = captureWrite(t);
-        const warnings = writeConfig(makeCfg());
+        const { warnings } = writeConfig(makeCfg());
 
         assert.equal(warnings.length, 0, 'no warnings for valid defaults');
         const content = out.get();
@@ -54,7 +58,7 @@ describe('writeConfig — kill-threshold cross-field validation', () => {
 
     test('sigkillPct > sigtermPct: both reverted to defaults + 1 warning', (t) => {
         captureWrite(t);
-        const warnings = writeConfig(makeCfg({ sigkillThresholdPct: 30, sigtermThresholdPct: 20 }));
+        const { warnings } = writeConfig(makeCfg({ sigkillThresholdPct: 30, sigtermThresholdPct: 20 }));
 
         assert.equal(warnings.length, 1);
         assert.ok(warnings[0].includes('sigkillThresholdPct'), 'warning names the bad field');
@@ -72,7 +76,7 @@ describe('writeConfig — kill-threshold cross-field validation', () => {
 
     test('sigkillPct === sigtermPct (equal = invalid): reverted + warning', (t) => {
         captureWrite(t);
-        const warnings = writeConfig(makeCfg({ sigkillThresholdPct: 20, sigtermThresholdPct: 20 }));
+        const { warnings } = writeConfig(makeCfg({ sigkillThresholdPct: 20, sigtermThresholdPct: 20 }));
         assert.equal(warnings.length, 1);
     });
 });
@@ -82,20 +86,20 @@ describe('writeConfig — kill-threshold cross-field validation', () => {
 describe('writeConfig — RSS threshold cross-field validation', () => {
     test('valid RSS thresholds: no warnings', (t) => {
         captureWrite(t);
-        const warnings = writeConfig(makeCfg());
+        const { warnings } = writeConfig(makeCfg());
         assert.equal(warnings.length, 0);
     });
 
     test('warnMB > emergMB: both reverted to defaults + 1 warning', (t) => {
         captureWrite(t);
-        const warnings = writeConfig(makeCfg({ vscodeRssWarnMB: 4000, vscodeRssEmergencyMB: 3000 }));
+        const { warnings } = writeConfig(makeCfg({ vscodeRssWarnMB: 4000, vscodeRssEmergencyMB: 3000 }));
         assert.equal(warnings.length, 1);
         assert.ok(warnings[0].includes('vscodeRssWarnMB'), 'warning names the bad field');
     });
 
     test('warnMB === emergMB (equal = invalid): reverted + warning', (t) => {
         captureWrite(t);
-        const warnings = writeConfig(makeCfg({ vscodeRssWarnMB: 3500, vscodeRssEmergencyMB: 3500 }));
+        const { warnings } = writeConfig(makeCfg({ vscodeRssWarnMB: 3500, vscodeRssEmergencyMB: 3500 }));
         assert.equal(warnings.length, 1);
     });
 
@@ -114,7 +118,7 @@ describe('writeConfig — RSS threshold cross-field validation', () => {
 describe('writeConfig — both cross-field checks invalid simultaneously', () => {
     test('two independent violations → two warnings in array', (t) => {
         captureWrite(t);
-        const warnings = writeConfig(makeCfg({
+        const { warnings } = writeConfig(makeCfg({
             sigkillThresholdPct:  30, sigtermThresholdPct:  20,  // inverted
             vscodeRssWarnMB:    4000, vscodeRssEmergencyMB: 3000, // inverted
         }));
@@ -183,10 +187,46 @@ describe('writeConfig — output file format', () => {
         }
     });
 
-    test('writeConfig returns empty array (not undefined) for valid input', (t) => {
+    test('writeConfig returns { warnings, changed } for valid input', (t) => {
         captureWrite(t);
         const result = writeConfig(makeCfg());
-        assert.ok(Array.isArray(result), 'must return an array');
-        assert.equal(result.length, 0);
+        assert.ok(Array.isArray(result.warnings), 'warnings must be an array');
+        assert.equal(result.warnings.length, 0);
+        assert.equal(typeof result.changed, 'boolean', 'changed must be a boolean');
+        assert.equal(result.changed, true, 'changed=true when file is missing');
+    });
+
+    test('changed=false when existing config matches new content', (t) => {
+        // Build the expected content string from defaults.
+        const warnKB  = 3400 * 1024;
+        const emergKB = 3800 * 1024;
+        const expected =
+            '# Auto-generated by Mem Watchdog VS Code extension.\n' +
+            '# Do not edit manually — changes will be overwritten on next VS Code startup.\n' +
+            '# To adjust thresholds, use VS Code Settings > Mem Watchdog.\n' +
+            'SIGTERM_THRESHOLD=25\n' +
+            'SIGKILL_THRESHOLD=15\n' +
+            'PSI_THRESHOLD=25\n' +
+            `VSCODE_RSS_WARN_KB=${warnKB}\n` +
+            `VSCODE_RSS_EMERG_KB=${emergKB}\n`;
+
+        t.mock.method(fs, 'mkdirSync', () => {});
+        t.mock.method(fs, 'readFileSync', () => expected);
+        t.mock.method(fs, 'writeFileSync', () => { throw new Error('should not be called'); });
+
+        const result = writeConfig(makeCfg());
+        assert.equal(result.changed, false, 'changed=false when content identical');
+        assert.equal(result.warnings.length, 0);
+    });
+
+    test('changed=true when existing config differs from new content', (t) => {
+        t.mock.method(fs, 'mkdirSync', () => {});
+        t.mock.method(fs, 'readFileSync', () => 'VSCODE_RSS_WARN_KB=999999\n');
+        let written = false;
+        t.mock.method(fs, 'writeFileSync', () => { written = true; });
+
+        const result = writeConfig(makeCfg());
+        assert.equal(result.changed, true, 'changed=true when content differs');
+        assert.ok(written, 'writeFileSync was called');
     });
 });


### PR DESCRIPTION
Closes #95

## Problem

`activate()` ran `installer.installOrUpgrade()` (daemon restart) **before** `configWriter.writeConfig()`. The daemon loaded stale config from the previous session — confirmed crash at 01:54:50 CDT with WARN=3.2 GB / EMERG=3.4 GB instead of 3.4 / 3.8 GB.

## Changes

### `configWriter.js`
- `writeConfig()` now compares new content with existing file before writing
- Returns `{ warnings, changed }` instead of plain `warnings` array
- Skips unnecessary writes when content is identical

### `extension.js`  
- **Swapped Steps 1 and 2**: config write → install/restart (was install/restart → config write)
- When installer returns `current` and config changed, explicit daemon restart
- Settings-change listener destructures new return type

### Tests
- 103 → **105 passing** (+2 new `changed`-flag tests for `writeConfig`)
- Updated `captureWrite` helper to mock `readFileSync` (new change detection)

### Docs
- Test count updated 103 → 105 across all 8 tracked files
- CHANGELOG entry for v0.3.11

## Gate evidence

```
bash test-watchdog.sh         # 18/18 PASS
cd vscode-extension && npm test  # 105/105 PASS  
bash -n mem-watchdog.sh       # OK
shellcheck mem-watchdog.sh watchdog-tray.sh install.sh  # clean
bash scripts/docs-integrity-check.sh  # 4/4 passed
```