### PR TITLE
chore(extension): bump version 0.3.11 → 0.3.12 (Marketplace skip)

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.12] — 2026-03-27
+
+### Notes
+- v0.3.11 was reserved in the Marketplace API during a partial upload; this release contains the same code as v0.3.11.
+
 ## [0.3.11] — 2026-03-27
 
 ### Fixed

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "mem-watchdog-status",
   "displayName": "Mem Watchdog",
   "description": "Prevents VS Code from being OOM-killed on ChromeOS Crostini — auto-installs a systemd memory watchdog daemon that kills Chrome/Playwright before the kernel kills VS Code.",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "publisher": "CurtisFranks",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {


### PR DESCRIPTION
v0.3.11 was reserved in the Marketplace API during a partial upload (same pattern as v0.3.9 → v0.3.10). This bumps to v0.3.12 with identical code.