### PR TITLE
chore: move test scripts to tests/ and watchdog-tray.sh to scripts/

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,13 +45,13 @@ Run all five checks before every commit. All must exit 0.
 
 ```bash
 # 1. Bash unit tests (18 tests, ~3 s) — run from repo root
-bash test-watchdog.sh
+bash tests/test-watchdog.sh
 
 # 2. Bash syntax check
 bash -n mem-watchdog.sh
 
 # 3. ShellCheck — SC1091 (source) and SC2317 (unreachable) are intentionally suppressed
-shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh
+shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh scripts/watchdog-tray.sh install.sh
 
 # 4. JS unit tests (105 tests, ~1 s) — must run from vscode-extension/
 cd vscode-extension && npm test
@@ -179,7 +179,7 @@ detection trivial.
 ./mem-watchdog.sh --dry-run
 
 # Run all 18 validation tests (~3 s, exits 0/1) — logs go to scratch/
-bash test-watchdog.sh
+bash tests/test-watchdog.sh
 
 # Service management
 systemctl --user status mem-watchdog

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,9 +25,9 @@ Closes #
 
 All five checks must exit 0 before this PR is ready for review.
 
-- [ ] `bash test-watchdog.sh` — 18 bash tests (run from repo root)
+- [ ] `bash tests/test-watchdog.sh` — 18 bash tests (run from repo root)
 - [ ] `bash -n mem-watchdog.sh` — bash syntax check
-- [ ] `shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh`
+- [ ] `shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh scripts/watchdog-tray.sh install.sh`
 - [ ] `cd vscode-extension && npm test` — 105 JS unit tests
 - [ ] `bash scripts/docs-integrity-check.sh` — documentation drift check
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,10 @@
 mem-watchdog.sh          ← core daemon; single infinite loop, no deps beyond coreutils
 mem-watchdog.service     ← systemd user unit (systemctl --user, NOT system)
 install.sh               ← shell-only installer (no VS Code required)
-test-watchdog.sh         ← 18-test suite; exits 0/1; logs to scratch/
+tests/
+  test-watchdog.sh       ← 18-test suite; exits 0/1; logs to scratch/
+scripts/
+  watchdog-tray.sh       ← optional yad system tray icon
 vscode-extension/
   extension.js           ← activate(): install → skill → config → commands → status bar (2s poll) → update check → chat
   installer.js           ← SHA-256 hash-based daemon auto-install/upgrade + MIN_SAFE guard
@@ -75,9 +78,9 @@ EXPLORE → PLAN → IMPLEMENT → GATE → REFLECT → COMMIT
 **GATE**: All five checks must exit 0 — no exceptions, no skips:
 
 ```bash
-bash test-watchdog.sh                                                          # 18 bash tests, ~3s
+bash tests/test-watchdog.sh                                                          # 18 bash tests, ~3s
 bash -n mem-watchdog.sh                                                        # syntax check
-shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh
+shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh scripts/watchdog-tray.sh install.sh
 cd vscode-extension && npm test                                                # 105 JS unit tests, ~1s
 bash scripts/docs-integrity-check.sh                                           # docs drift check
 ```
@@ -96,8 +99,8 @@ npm run test:coverage      # + c8 V8 lcov output
 npm run test:stress        # pileup guard + event-loop lag + heap scenarios
 npx vsce package           # → mem-watchdog-status-x.y.z.vsix
 
-bash test-watchdog.sh      # 18 bash tests (repo root — REPO=$(dirname $0), not scripts/)
-bash test-pressure.sh      # live memory allocation tests; needs RAM < 40% free
+bash tests/test-watchdog.sh      # 18 bash tests (repo root — REPO=$(dirname $0)/.., not scripts/)
+bash tests/test-pressure.sh      # live memory allocation tests; needs RAM < 40% free
 ./mem-watchdog.sh --dry-run
 
 systemctl --user {status,restart,stop} mem-watchdog

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@
 # a running mem-watchdog service, and VS Code installed — none of which are
 # available on a GitHub Actions runner. Run it manually before pushing:
 #
-#   bash test-watchdog.sh   # on your Crostini machine
+#   bash tests/test-watchdog.sh   # on your Crostini machine
 #
 # The CI gate covers: daemon syntax, shellcheck, all 105 JS unit tests, and docs integrity.
 # ──────────────────────────────────────────────────────────────────────────────
@@ -49,7 +49,7 @@ jobs:
         run: |
           sudo apt-get install -y shellcheck -q
           shellcheck --shell=bash -e SC1091,SC2317 \
-            mem-watchdog.sh watchdog-tray.sh install.sh
+            mem-watchdog.sh scripts/watchdog-tray.sh install.sh
 
   # ── Job 2: Extension unit tests (Node matrix) ────────────────────────────
   test-extension:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Installs](https://img.shields.io/visual-studio-marketplace/i/CurtisFranks.mem-watchdog-status?color=00d4aa)](https://marketplace.visualstudio.com/items?itemName=CurtisFranks.mem-watchdog-status)
 [![License: PolyForm NC](https://img.shields.io/badge/License-PolyForm%20NC%201.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-ChromeOS%20Crostini-4285f4)](https://chromeos.dev/en/linux)
-[![Tests](https://img.shields.io/badge/bash-18%2F18-brightgreen)](test-watchdog.sh)
+[![Tests](https://img.shields.io/badge/bash-18%2F18-brightgreen)](tests/test-watchdog.sh)
 [![Tests](https://img.shields.io/badge/js-105%2F105-brightgreen)](vscode-extension/package.json)
 
 _`earlyoom` hard-crashes on Crostini (exit 104, every 3 seconds, zero protection). This replaces it with a VS Code-aware watchdog that kills Chrome before the kernel OOM-kills VS Code._
@@ -102,9 +102,16 @@ crostini-mem-watchdog/
 ├── mem-watchdog.sh              ← core daemon (bash, coreutils only)
 ├── mem-watchdog.service         ← systemd user service unit
 ├── install.sh                   ← shell-only installer (no VS Code required)
-├── test-watchdog.sh             ← 18-test validation suite
-├── test-pressure.sh             ← live memory pressure tests
-├── watchdog-tray.sh             ← optional: yad system tray icon
+├── tests/
+│   ├── test-watchdog.sh         ← 18-test validation suite
+│   ├── test-pressure.sh         ← live memory pressure tests
+│   ├── stress-harness.sh        ← Playwright stress test harness
+│   └── stress-playwright.js     ← Playwright automation driver
+├── scripts/
+│   ├── watchdog-tray.sh         ← optional: yad system tray icon
+│   ├── docs-integrity-check.sh  ← documentation drift check
+│   ├── extension-footprint-advisor.sh ← extension RAM advisor (prototype)
+│   └── psi-calibration.sh       ← PSI threshold calibration
 └── vscode-extension/            ← VS Code extension (primary install path)
     ├── extension.js             ← activate(): install → skill → config → commands → status bar → update check → chat
     ├── installer.js             ← SHA-256 hash-based auto-install/upgrade + MIN_SAFE guard
@@ -158,14 +165,14 @@ crostini-mem-watchdog/
 All 4 gates must pass before any change is published:
 
 ```bash
-bash test-watchdog.sh              # 18 bash tests (~3 s) — service, OOM scores, PSI, SwapFree safety, SIGTERM
+bash tests/test-watchdog.sh              # 18 bash tests (~3 s) — service, OOM scores, PSI, SwapFree safety, SIGTERM
 cd vscode-extension && npm test    # 105 JS unit tests (~1 s) — extension state machine, activation singleton, pileup guard, utils
 bash -n mem-watchdog.sh            # bash syntax check
-shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh watchdog-tray.sh install.sh
+shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh scripts/watchdog-tray.sh install.sh
 ```
 
 ```bash
-bash test-pressure.sh    # live: allocates memory, verifies watchdog fires (requires < 40% RAM free)
+bash tests/test-pressure.sh    # live: allocates memory, verifies watchdog fires (requires < 40% RAM free)
 ```
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -173,5 +173,5 @@ echo "└───────────────────────�
 echo ""
 echo "  Monitor:   systemctl --user status mem-watchdog"
 echo "  Live log:  journalctl --user -u mem-watchdog -f"
-echo "  Validate:  bash test-watchdog.sh"
+echo "  Validate:  bash tests/test-watchdog.sh"
 echo ""

--- a/scripts/watchdog-tray.sh
+++ b/scripts/watchdog-tray.sh
@@ -12,7 +12,7 @@
 # Very low resource: ~3 MB RAM, 0% CPU at idle (sleeps between updates).
 #
 # USAGE:
-#   Start:   ./scripts/watchdog-tray.sh &
+#   Start:   bash scripts/watchdog-tray.sh &
 #   Stop:    pkill -f watchdog-tray.sh
 #   Autostart: add to ~/.config/autostart/ (see below)
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test-pressure.sh
+++ b/tests/test-pressure.sh
@@ -31,9 +31,9 @@
 #   See docs/technical/system-stability.md §10 for the cgroup v1 technique.
 #
 # Usage:
-#   bash test-pressure.sh              # full suite (requires ~1 GB headroom)
-#   bash test-pressure.sh --dry-run    # show what would happen without allocating
-#   bash test-pressure.sh --adaptive   # child-cgroup isolation: Tests 1 & 5 run
+#   bash tests/test-pressure.sh              # full suite (requires ~1 GB headroom)
+#   bash tests/test-pressure.sh --dry-run    # show what would happen without allocating
+#   bash tests/test-pressure.sh --adaptive   # child-cgroup isolation: Tests 1 & 5 run
 #                                      # at any RAM level (never skip for "too much
 #                                      # free RAM").  Requires sudo -n and cgroup
 #                                      # mkdir.  Falls back to capped mode on failure.
@@ -41,7 +41,7 @@
 
 set -euo pipefail
 
-REPO="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
 LOG="$REPO/scratch/pressure-test-$(date '+%Y%m%d-%H%M%S').log"
 mkdir -p "$REPO/scratch"
 

--- a/tests/test-watchdog.sh
+++ b/tests/test-watchdog.sh
@@ -5,10 +5,10 @@
 # Runs a finite set of checks, logs results to scratch/, exits cleanly.
 # NEVER runs indefinitely — every test has an explicit timeout.
 #
-# Usage: bash test-watchdog.sh
+# Usage: bash tests/test-watchdog.sh
 # ─────────────────────────────────────────────────────────────────────────────
 
-REPO="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
 LOG="$REPO/scratch/watchdog-test-$(date '+%Y%m%d-%H%M%S').log"
 WATCHDOG="$REPO/mem-watchdog.sh"
 
@@ -193,7 +193,7 @@ fi
 # ── TEST 12: watchdog-tray.sh has no /tmp writes (only mkfifo PIPE which is cleaned up) ──
 tee_log ""
 tee_log "── Test 12: watchdog-tray.sh uses only a named FIFO (no stray /tmp writes)"
-tray_tmp=$(grep -c 'echo.*>/tmp/\|write.*>/tmp/\|tee.*/tmp/' "$REPO/watchdog-tray.sh" 2>/dev/null)
+tray_tmp=$(grep -c 'echo.*>/tmp/\|write.*>/tmp/\|tee.*/tmp/' "$REPO/scripts/watchdog-tray.sh" 2>/dev/null)
 tray_tmp=${tray_tmp:-0}
 # watchdog-tray.sh intentionally uses mktemp for a named FIFO (cleaned up on EXIT trap) — that is allowed.
 # The check ensures no uncleaned log/data writes to /tmp were introduced.
@@ -290,29 +290,29 @@ tee_log "── Test 17: test-pressure.sh cgroup hierarchy detection"
 cg_test_ok=true
 
 # Verify the function exists in test-pressure.sh
-if ! grep -q 'detect_cgroup_mode()' "$REPO/test-pressure.sh"; then
+if ! grep -q 'detect_cgroup_mode()' "$REPO/tests/test-pressure.sh"; then
   tee_log "    Missing detect_cgroup_mode() function in test-pressure.sh"
   cg_test_ok=false
 fi
 
 # Verify both v1 and v2 code paths exist
-if ! grep -q 'memory\.max' "$REPO/test-pressure.sh"; then
+if ! grep -q 'memory\.max' "$REPO/tests/test-pressure.sh"; then
   tee_log "    Missing cgroup v2 memory.max reference"
   cg_test_ok=false
 fi
-if ! grep -q 'memory\.limit_in_bytes' "$REPO/test-pressure.sh"; then
+if ! grep -q 'memory\.limit_in_bytes' "$REPO/tests/test-pressure.sh"; then
   tee_log "    Missing cgroup v1 memory.limit_in_bytes reference"
   cg_test_ok=false
 fi
 
 # Verify mode banner is emitted
-if ! grep -q 'Cgroup mode:' "$REPO/test-pressure.sh"; then
+if ! grep -q 'Cgroup mode:' "$REPO/tests/test-pressure.sh"; then
   tee_log "    Missing cgroup mode banner output"
   cg_test_ok=false
 fi
 
 # Live detection: run --dry-run and verify a mode is reported
-dry_output=$(bash "$REPO/test-pressure.sh" --dry-run 2>&1 || true)
+dry_output=$(bash "$REPO/tests/test-pressure.sh" --dry-run 2>&1 || true)
 if echo "$dry_output" | grep -qE 'Cgroup mode: (v1|v2)'; then
   detected_mode=$(echo "$dry_output" | grep 'Cgroup mode:' | awk '{print $NF}')
   tee_log "    Live detection: ${detected_mode}"


### PR DESCRIPTION
## Summary

Root minimalism audit: 3 shell files at root failed the 4-condition test.

| File | Destination | Reason |
|---|---|---|
| `test-watchdog.sh` | `tests/` | Test suite, not primary entry point |
| `test-pressure.sh` | `tests/` | Test suite, not primary entry point |
| `watchdog-tray.sh` | `scripts/` | Optional auxiliary, not primary entry point |

### Path resolution fix
`REPO=` changed from `$(dirname $0)` to `$(dirname $0)/..` (matching existing `tests/stress-harness.sh` convention).

### Cross-references updated
README, copilot-instructions, ci.yml, CONTRIBUTING, PULL_REQUEST_TEMPLATE, install.sh, test-watchdog.sh internal refs.

### Root now contains only
`mem-watchdog.sh`, `install.sh`, `mem-watchdog.service`, `journald-limits.conf`, plus metadata files.

### Verification
- All 18 bash tests pass at new location (REPO resolves correctly) ✓
- shellcheck passes on new `scripts/watchdog-tray.sh` path ✓
- All 5 gate checks pass ✓

Closes #105