### PR TITLE
docs: sync CONTRIBUTING.md architecture tree with actual repo structure

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -146,7 +146,12 @@ known failure modes.
 mem-watchdog.sh          ← core daemon; single infinite loop, no deps beyond coreutils
 mem-watchdog.service     ← systemd user unit (systemctl --user, NOT system)
 install.sh               ← shell-only installer (no VS Code required)
-test-watchdog.sh         ← 18-test suite; exits 0/1; logs to scratch/
+tests/
+  test-watchdog.sh       ← 18-test suite; exits 0/1; logs to scratch/
+  test-pressure.sh       ← live memory pressure tests
+scripts/
+  watchdog-tray.sh       ← optional yad system tray icon
+  extension-footprint-advisor.sh ← extension RAM advisor (prototype)
 vscode-extension/
   extension.js           ← activate(): install → skill → config → commands → status bar (2s poll) → update check → chat
   installer.js           ← SHA-256 hash-based daemon auto-install/upgrade + MIN_SAFE guard

--- a/docs/workflow/learnings.md
+++ b/docs/workflow/learnings.md
@@ -20,6 +20,21 @@
 
 ---
 
+### 2026-03-27 — Post-merge governance and docs-drift must be explicit checklist items, not assumed
+
+**Context**: After merging PRs #104 and #106 (repo structure cleanup — moving shell scripts to `tests/` and `scripts/`), the agent declared the task complete without running the post-merge governance checklist: CHANGELOG review, docs drift scan, `repo-profile-governance` audit, or learnings entry.
+
+**Discovery**: The PR implementation correctly updated `README.md`, `.github/copilot-instructions.md`, CI workflows, PR template, and `install.sh`. But `.github/CONTRIBUTING.md` had its own architecture tree (line 147) that was **not** updated — it still showed `test-watchdog.sh` at the repo root with no `tests/` or `scripts/` directories. This was found only when the post-merge governance audit was explicitly requested.
+
+The root cause: CONTRIBUTING.md's architecture tree was a copy-divergence from the canonical trees in `copilot-instructions.md` and `README.md`. The PR's cross-reference sweep searched for *invocation paths* (`bash tests/test-watchdog.sh`) which were all correct, but didn't check *structural diagrams* which had a separate stale copy of the directory layout.
+
+**Application**:
+- The post-merge governance checklist (CHANGELOG, docs drift, `repo-profile-governance`, learnings) must be an explicit final step in every PR merge — not assumed complete because the implementation updated "the obvious files."
+- Architecture trees are duplicated across 3 files (`copilot-instructions.md`, `README.md`, `CONTRIBUTING.md`). When updating one, always grep for `## Architecture` across all `.md` files and update all instances.
+- Cross-reference sweeps must search for both *invocation patterns* (command paths) and *structural patterns* (directory trees, code blocks showing file layouts).
+
+---
+
 ### 2026-03-27 — Startup burst RSS gate must match eff_warn, not a lower static threshold
 
 **Context**: VS Code showed "A shared background process terminated unexpectedly" pop-up 3 times in 5 minutes during a normal Copilot Chat session. Journal investigation revealed the watchdog killed Network Service (132 MB), Shared Process (192 MB), and File Watcher (110 MB) at 80–82% free RAM.


### PR DESCRIPTION
## Summary

Fixes the CONTRIBUTING.md architecture tree that was missed during the PR #106 cross-reference update.

## Changes

1. **CONTRIBUTING.md architecture tree** (line 147): Updated to show `tests/` and `scripts/` directories with all their files, matching the canonical trees in `copilot-instructions.md` and `README.md`.

2. **Learnings entry**: Added entry documenting that architecture trees are duplicated across 3 files and all instances must be updated when structure changes. Cross-reference sweeps must check structural diagrams, not just invocation paths.

## Gate Evidence

- `bash -n mem-watchdog.sh` ✅
- `shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh scripts/watchdog-tray.sh install.sh` ✅
- `bash tests/test-watchdog.sh` → 18/18 ✅
- `npm test` → 105/105 ✅
- `bash scripts/docs-integrity-check.sh` → 4/4 ✅

## Post-merge governance

This PR IS the post-merge governance remediation for PRs #104 and #106.

Closes #107