### PR TITLE
fix(installer): version regex fails on export prefix — downgrade protection was dead code

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,7 +84,7 @@ EXPLORE → PLAN → IMPLEMENT → GATE → REFLECT → COMMIT
 bash tests/test-watchdog.sh                                                          # 18 bash tests, ~3s
 bash -n mem-watchdog.sh                                                        # syntax check
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh scripts/watchdog-tray.sh install.sh
-cd vscode-extension && npm test                                                # 105 JS unit tests, ~1s
+cd vscode-extension && npm test                                                # 106 JS unit tests, ~1s
 bash scripts/docs-integrity-check.sh                                           # docs drift check
 ```
 
@@ -97,7 +97,7 @@ bash scripts/docs-integrity-check.sh                                           #
 ```bash
 cd vscode-extension
 npm run build              # populate resources/ for dev (gitignored; required before vsce package)
-npm test                   # 105 unit tests via node:test (~1s)
+npm test                   # 106 unit tests via node:test (~1s)
 npm run test:coverage      # + c8 V8 lcov output
 npm run test:stress        # pileup guard + event-loop lag + heap scenarios
 npx vsce package           # → mem-watchdog-status-x.y.z.vsix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@
 #
 #   bash tests/test-watchdog.sh   # on your Crostini machine
 #
-# The CI gate covers: daemon syntax, shellcheck, all 105 JS unit tests, and docs integrity.
+# The CI gate covers: daemon syntax, shellcheck, all 106 JS unit tests, and docs integrity.
 # ──────────────────────────────────────────────────────────────────────────────
 
 name: CI
@@ -74,7 +74,7 @@ jobs:
         run: npm ci
         working-directory: vscode-extension
 
-      - name: npm test (105 unit tests)
+      - name: npm test (106 unit tests)
         run: npm test
         working-directory: vscode-extension
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: PolyForm NC](https://img.shields.io/badge/License-PolyForm%20NC%201.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-ChromeOS%20Crostini-4285f4)](https://chromeos.dev/en/linux)
 [![Tests](https://img.shields.io/badge/bash-18%2F18-brightgreen)](tests/test-watchdog.sh)
-[![Tests](https://img.shields.io/badge/js-105%2F105-brightgreen)](vscode-extension/package.json)
+[![Tests](https://img.shields.io/badge/js-106%2F106-brightgreen)](vscode-extension/package.json)
 
 _`earlyoom` hard-crashes on Crostini (exit 104, every 3 seconds, zero protection). This replaces it with a VS Code-aware watchdog that kills Chrome before the kernel OOM-kills VS Code._
 
@@ -166,7 +166,7 @@ All 4 gates must pass before any change is published:
 
 ```bash
 bash tests/test-watchdog.sh              # 18 bash tests (~3 s) — service, OOM scores, PSI, SwapFree safety, SIGTERM
-cd vscode-extension && npm test    # 105 JS unit tests (~1 s) — extension state machine, activation singleton, pileup guard, utils
+cd vscode-extension && npm test    # 106 JS unit tests (~1 s) — extension state machine, activation singleton, pileup guard, utils
 bash -n mem-watchdog.sh            # bash syntax check
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh scripts/watchdog-tray.sh install.sh
 ```

--- a/vscode-extension/installer.js
+++ b/vscode-extension/installer.js
@@ -47,7 +47,7 @@ function sha256(filePath) {
 function watchdogVersion(filePath) {
     try {
         const src = fs.readFileSync(filePath, 'utf8');
-        const m = src.match(/^WATCHDOG_VERSION=([0-9]+(?:\.[0-9]+)?)/m);
+        const m = src.match(/^(?:export\s+)?WATCHDOG_VERSION=([0-9]+(?:\.[0-9]+)?)/m);
         return m ? Number(m[1]) : 0;
     } catch (_) {
         return 0;

--- a/vscode-extension/test/unit/installer.test.js
+++ b/vscode-extension/test/unit/installer.test.js
@@ -170,8 +170,9 @@ describe('installOrUpgrade — hash comparison paths', () => {
     });
 
     test('installed daemon newer than bundled: skips downgrade and stays current', async (t) => {
-        const BUNDLED_OLDER = '#!/usr/bin/env bash\nWATCHDOG_VERSION=20260313.1\n';
-        const INSTALLED_NEWER = '#!/usr/bin/env bash\nWATCHDOG_VERSION=20260313.2\n';
+        // Use 'export WATCHDOG_VERSION=...' to match real daemon format
+        const BUNDLED_OLDER = '#!/usr/bin/env bash\nexport WATCHDOG_VERSION=20260313.1\n';
+        const INSTALLED_NEWER = '#!/usr/bin/env bash\nexport WATCHDOG_VERSION=20260313.2\n';
         const olderHash = crypto.createHash('sha256').update(BUNDLED_OLDER).digest('hex');
 
         t.mock.method(fs, 'existsSync', (p) => {
@@ -203,7 +204,8 @@ describe('installOrUpgrade — hash comparison paths', () => {
         // Scenario: bundled daemon is old (below MIN_SAFE) AND installed is also
         // old — the hashes match (same file), so installer returns 'current' but
         // _warnIfOutdated fires because both are below MIN_SAFE.
-        const OLD_DAEMON = '#!/usr/bin/env bash\nWATCHDOG_VERSION=20260316.1\n';
+        // Use 'export WATCHDOG_VERSION=...' to match real daemon format
+        const OLD_DAEMON = '#!/usr/bin/env bash\nexport WATCHDOG_VERSION=20260316.1\n';
         const oldHash = crypto.createHash('sha256').update(OLD_DAEMON).digest('hex');
 
         t.mock.method(fs, 'existsSync', () => true);
@@ -226,5 +228,31 @@ describe('installOrUpgrade — hash comparison paths', () => {
             'warning should mention critical bugs');
         assert.ok(mockWindow._warnMessages[0].includes('20260316.1'),
             'warning should mention the outdated version');
+    });
+
+    test('version regex handles export prefix (real daemon format)', async (t) => {
+        // This is the REAL daemon format — 'export WATCHDOG_VERSION=...'
+        // The regex must handle the 'export' prefix to prevent downgrades.
+        const BUNDLED_OLDER = '#!/usr/bin/env bash\nexport WATCHDOG_VERSION=20260326.5   # old\n';
+        const INSTALLED_NEWER = '#!/usr/bin/env bash\nexport WATCHDOG_VERSION=20260329.1   # new\n';
+        const olderHash = crypto.createHash('sha256').update(BUNDLED_OLDER).digest('hex');
+
+        t.mock.method(fs, 'existsSync', () => true);
+        t.mock.method(fs, 'readFileSync', (p) => {
+            if (p === '/fake/ext/resources/mem-watchdog.sh') { return BUNDLED_OLDER; }
+            if (typeof p === 'string' && p.includes('.local/bin/mem-watchdog.sh')) { return INSTALLED_NEWER; }
+            throw new Error(`unexpected readFileSync: ${p}`);
+        });
+
+        // File writes indicate downgrade — must NOT happen
+        t.mock.method(fs, 'mkdirSync', () => { throw new Error('should not mkdir on downgrade skip'); });
+        t.mock.method(fs, 'copyFileSync', () => { throw new Error('should not copy files on downgrade skip'); });
+        t.mock.method(fs, 'chmodSync', () => { throw new Error('should not chmod on downgrade skip'); });
+
+        const ctx = makeContext(olderHash);
+        const result = await installOrUpgrade(ctx);
+
+        assert.equal(result, 'current',
+            'must skip downgrade when installed (export WATCHDOG_VERSION=20260329.1) > bundled (export WATCHDOG_VERSION=20260326.5)');
     });
 });


### PR DESCRIPTION
## Summary

Fixes the `watchdogVersion()` regex in `installer.js` which never matched the real daemon format (`export WATCHDOG_VERSION=...`), rendering all version-based downgrade protection dead code since its introduction.

## Root Cause

The daemon has **always** declared its version as:
```bash
export WATCHDOG_VERSION=20260329.1   # comment
```

But the regex expected `^WATCHDOG_VERSION=` — no `export` prefix. Both `watchdogVersion(bundledSh)` and `watchdogVersion(installedScript)` returned `0`. The comparison `0 > 0` is always `false`, so the downgrade guard was bypassed on every activation.

## Impact

The 2026-03-29 00:45:34 crash was caused by this bug:
1. `00:22:55` — v20260329.1 daemon deployed (PID 26062) with Playwright-awareness fix
2. `00:33:43` — frankspressurewashing VS Code window opened
3. `00:33:48` — Extension v0.3.12 activated → installer saw hash mismatch → version check returned `0 > 0 = false` → **overwrote v20260329.1 with v20260326.5**
4. `00:45:34` — Old daemon (no `playwright_is_active()`) fired CHROME-EXCESS: 11 PIDs → SIGKILL 8 → fight loop → 3 `kill_vscode_main` events

## Changes

| File | Change |
|---|---|
| `installer.js` | Regex: `^WATCHDOG_VERSION=` → `^(?:export\s+)?WATCHDOG_VERSION=` |
| `installer.test.js` | Existing tests updated to use real daemon format (`export WATCHDOG_VERSION=...`); new test for export-prefix downgrade scenario |
| `README.md`, `copilot-instructions.md`, `ci.yml` | Test count 105 → 106 |

## Gate evidence

- `bash -n mem-watchdog.sh` ✅
- `shellcheck` ✅
- `bash tests/test-watchdog.sh` — 18/18 ✅
- `npm test` — 106/106 ✅
- `docs-integrity-check.sh` — 4/4 ✅

Closes #112