### PR TITLE
docs: update extension + repo profiles for v0.3.13 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ This watchdog reads only `MemAvailable` and `MemTotal` — both correct on this 
 
 **Language-server protection:** Built-in language servers (HTML, JSON, CSS, Markdown, ESLint) and the Extension Host process are excluded from the helper-kill candidate pool at normal severity. These 80–120 MB processes are subject to VS Code's 5-crash-in-3-minutes permanent death threshold — killing them saves <2% of memory for 2 seconds (they respawn immediately) while permanently disabling language intelligence until a full VS Code restart. Only at true emergency severity (RSS ≥ 3.8 GB) are they considered as last-resort targets.
 
+**Playwright awareness:** When a Playwright MCP session is active (detected via `node.*playwright`), the daemon defers non-critical Chrome kills and skips the `CHROME_COUNT_MAX` cap — Playwright legitimately spawns 5–10 Chrome PIDs. At true emergency severity (≤ 15% free), Chrome is always killed regardless (safety net).
+
 - Checks every **2 seconds** (4s was confirmed too slow — missed a 4 GB spike in < 4s on 2026-03-05)
 - **Startup mode**: 0.5 s polling for 90 s after new VS Code PIDs detected — catches extension-host spikes during startup
 - Reads only `MemAvailable`, `MemTotal`, and `/proc/pressure/memory` (PSI) — all safe on Crostini
@@ -114,7 +116,7 @@ crostini-mem-watchdog/
 │   └── psi-calibration.sh       ← PSI threshold calibration
 └── vscode-extension/            ← VS Code extension (primary install path)
     ├── extension.js             ← activate(): install → skill → config → commands → status bar → update check → chat
-    ├── installer.js             ← SHA-256 hash-based auto-install/upgrade + MIN_SAFE guard
+    ├── installer.js             ← SHA-256 hash-based auto-install/upgrade + downgrade protection + MIN_SAFE guard
     ├── configWriter.js          ← VS Code Settings → ~/.config/mem-watchdog/config.sh
     ├── commands.js              ← dashboard, preflight, killChrome, restartService
     ├── updateChecker.js         ← GitHub Releases API self-update check (24h throttled)

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -21,6 +21,8 @@ The daemon acts on these conditions (checked every 2 seconds):
 
 **Language-server protection:** Built-in language servers (HTML, JSON, CSS, Markdown, ESLint) and the Extension Host process (hosting Copilot, Playwright MCP, and all extensions) are excluded from the helper-kill candidate pool at normal severity. These small processes (80–120 MB) are subject to VS Code's 5-crash-in-3-minutes permanent death threshold — killing one saves negligible memory while permanently disabling language intelligence or all extensions. They are only considered as last-resort targets at true emergency severity (RSS ≥ 3.8 GB).
 
+**Playwright awareness:** When a Playwright MCP session is active (detected via `node.*playwright`), the daemon automatically defers non-critical Chrome kills — Playwright legitimately spawns 5–10 Chrome PIDs. The Chrome process count cap (`CHROME_COUNT_MAX`) is also skipped during active sessions. At true emergency severity (≤ 15% free RAM), Chrome is always killed regardless.
+
 **Startup mode:** when new VS Code PIDs appear, the daemon switches to **0.5 s polling for 90 s** and raises the RSS emergency threshold to 4.0 GB — catching the extension-host spike that caused the crash this tool was built to prevent (0 → 4 GB RSS in under 2 seconds during startup).
 
 ---
@@ -119,7 +121,7 @@ VS Code Extension (this)            Systemd Daemon (independent process)
 ## How It Works
 
 On every VS Code activation:
-1. The bundled `mem-watchdog.sh` is SHA-256 compared to the installed version. If different, it is upgraded and the service is restarted automatically.
+1. The bundled `mem-watchdog.sh` is SHA-256 compared to the installed version. If different, it is upgraded and the service is restarted automatically. **Downgrade protection** ensures a newer manually-deployed daemon is never overwritten by an older bundled version.
 2. A Copilot skill is installed/refreshed at `~/.copilot/skills/mem-watchdog-ops/`.
 3. VS Code Settings are written to `~/.config/mem-watchdog/config.sh`. The daemon sources this file so threshold changes take effect on the next restart — without reinstalling.
 4. OOM scores are tuned: `oom_score_adj=0` for VS Code (counters Electron's default 200–300), `oom_score_adj=1000` for Chrome (kernel kills it first, no root required).
@@ -172,9 +174,9 @@ Commercial use requires a paid license. See [COMMERCIAL-LICENSE.md](https://gith
 git clone https://github.com/chf3198/crostini-mem-watchdog.git
 cd crostini-mem-watchdog/vscode-extension
 npm run build          # populate resources/ from repo root
-npm test               # 105 JS unit tests via node:test (zero-install)
+npm test               # 106 JS unit tests via node:test (zero-install)
 npm run test:coverage  # same + c8 V8 coverage report
 npm run test:stress    # stress scenarios: pileup guard, EL lag, heap usage
 ```
 
-105 unit tests covering `readMeminfo`/`readPsi`/`sh()`/`checkServiceStatus()`, config validation, command handlers, installer decision logic, `activate()` singleton lifecycle, the `update()` state machine + pileup guard, update checker (version comparison, throttling, dismissal), installer MIN_SAFE_DAEMON_VERSION guard, skill installer (install/update/skip), and `@memwatchdog` chat participant (all 4 commands, profile detection/application, followups, API availability guard).
+106 unit tests covering `readMeminfo`/`readPsi`/`sh()`/`checkServiceStatus()`, config validation, command handlers, installer decision logic, `activate()` singleton lifecycle, the `update()` state machine + pileup guard, update checker (version comparison, throttling, dismissal), installer MIN_SAFE_DAEMON_VERSION guard, installer downgrade protection (export-prefix version parsing), skill installer (install/update/skip), and `@memwatchdog` chat participant (all 4 commands, profile detection/application, followups, API availability guard).


### PR DESCRIPTION
Updates both READMEs with the two major features shipped in v0.3.13:

1. **Playwright awareness** (daemon v20260329.1) — non-critical Chrome kills deferred during active Playwright sessions, CHROME_COUNT_MAX skipped
2. **Installer downgrade protection** (ext v0.3.13) — version regex now handles `export WATCHDOG_VERSION=...` format

Also fixes extension README test count (105 → 106) and adds downgrade protection to test coverage description.

These are the profile updates that should have been part of the post-merge governance for PRs #113–#115.