### PR TITLE
chore(release): v0.3.16

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.3.16] — 2026-03-30
 
 ### Added
 - **V8 memory flags in optimizer** ([#124](https://github.com/chf3198/crostini-mem-watchdog/issues/124)) — `ARGV_PROFILE` `js-flags` entry now includes 4 new flags benchmarked in [#120](https://github.com/chf3198/crostini-mem-watchdog/issues/120) (53% per-isolate RSS reduction, p99 GC < 35ms): `--optimize-for-size`, `--flush-baseline-code`, `--concurrent-turbofan-max-threads=1`, `--concurrent-maglev-max-threads=1`.

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "mem-watchdog-status",
   "displayName": "Mem Watchdog",
   "description": "Prevents VS Code from being OOM-killed on ChromeOS Crostini — auto-installs a systemd memory watchdog daemon that kills Chrome/Playwright before the kernel kills VS Code.",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "publisher": "CurtisFranks",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {


### PR DESCRIPTION
## Release v0.3.16

Version bump and CHANGELOG finalization for the V8 memory flags feature (#124).

### Changes
- `package.json`: 0.3.15 → 0.3.16
- `CHANGELOG.md`: `[Unreleased]` → `[0.3.16] — 2026-03-30`

### Post-merge steps
After CI green + merge:
```
git tag v0.3.16 <merge-sha> && git push origin v0.3.16
```
This triggers `publish.yml` → validates tag ↔ manifest → publishes to Marketplace.

### release-version-integrity evidence
- ✅ package.json version = 0.3.16
- ✅ CHANGELOG head = [0.3.16]
- ✅ vsce ls: 24 files, no .env, no test/
- ✅ publish.yml: tag-version validation gate present
- ✅ 146/146 tests, docs-integrity 4/4