### PR TITLE
chore(release): v0.3.17

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.17] — 2026-03-31
+
+### Added
+- **SLEEP mode daemon bundle** ([#139](https://github.com/chf3198/crostini-mem-watchdog/issues/139)) — daemon updated to v20260331.1, which honours the managed-window signal file protocol: writing `SLEEP` to `~/.config/mem-watchdog/mode` defers all kills and cgroup ops until the file is removed. Required for FPW publish automation compatibility (`signalMemWatchdogSleep`/`clearMemWatchdogSleep`).
+
+### Changed
+- **`MIN_SAFE_DAEMON_VERSION` raised to `20260331.1`** — extensions with daemon < v20260331.1 installed will show a warning to upgrade. Older daemons ignore the SLEEP mode signal file and will interfere with Playwright/publish automation.
+
 ## [0.3.16] — 2026-03-30
 
 ### Added

--- a/vscode-extension/installer.js
+++ b/vscode-extension/installer.js
@@ -30,7 +30,7 @@ const INSTALLED_SERVICE  = path.join(INSTALL_SVC_DIR, 'mem-watchdog.service');
 // Minimum daemon version that is considered safe. Daemons below this version
 // have known critical bugs (language-server kills, Extension Host kills via
 // blind process-type guards, utility process kills at WARN causing terminal loss).
-const MIN_SAFE_DAEMON_VERSION = '20260325.8';
+const MIN_SAFE_DAEMON_VERSION = '20260331.1';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "mem-watchdog-status",
   "displayName": "Mem Watchdog",
   "description": "Prevents VS Code from being OOM-killed on ChromeOS Crostini — auto-installs a systemd memory watchdog daemon that kills Chrome/Playwright before the kernel kills VS Code.",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "publisher": "CurtisFranks",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {


### PR DESCRIPTION
## Summary

Cuts v0.3.17 — bundles daemon v20260331.1 (SLEEP mode signal protocol) and raises `MIN_SAFE_DAEMON_VERSION` to match.

## Changes

- `package.json`: 0.3.16 → 0.3.17
- `installer.js`: `MIN_SAFE_DAEMON_VERSION` '20260325.8' → '20260331.1'
- `CHANGELOG.md`: v0.3.17 entry added
- `resources/` (build artifact): daemon v20260330.2 → v20260331.1 (built by `npm run build` via vscode:prepublish)

## Why MIN_SAFE required a jump

Daemon v20260331.1 introduced the SLEEP mode signal file protocol (Issue #139). The FPW publish automation (`signalMemWatchdogSleep()`/`clearMemWatchdogSleep()`) depends on this. Any older daemon silently ignores the signal file — the watchdog stays in `mode=normal` and will SIGTERM Chrome during publish runs. This is a breaking behavioral dependency.

## Gate evidence

| Gate | Result |
|---|---|
| `bash -n mem-watchdog.sh` | ✅ OK |
| `shellcheck` | ✅ OK |
| `npm test` | ✅ 146/146 pass |
| `bash tests/test-watchdog.sh` | ✅ 18/18 pass |
| `docs-integrity-check.sh` | ✅ 4/4 pass |

Closes #139