### PR TITLE
docs(extension): self-anneal release governance controls

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -101,6 +101,7 @@ npm test                   # 146 unit tests via node:test (~1s)
 npm run test:coverage      # + c8 V8 lcov output
 npm run test:stress        # pileup guard + event-loop lag + heap scenarios
 npx vsce package           # → mem-watchdog-status-x.y.z.vsix
+bash scripts/release-integrity-check.sh --post-publish   # release metadata guard (tag/release/Marketplace + MIN_SAFE)
 
 bash tests/test-watchdog.sh      # 18 bash tests (repo root — REPO=$(dirname $0)/.., not scripts/)
 bash tests/test-pressure.sh      # live memory allocation tests; needs RAM < 40% free

--- a/.github/instructions/skill-routing.instructions.md
+++ b/.github/instructions/skill-routing.instructions.md
@@ -19,4 +19,8 @@ Use repository and global customization layers together for every task:
    - Run `docs-drift-maintenance` to detect stale documentation
    - Add learnings entry if a significant discovery was made
    - If the merge changes extension behavior, run `release-version-integrity` to
-     validate tag/manifest/changelog alignment, then publish the new version
+       validate tag/manifest/changelog alignment, then publish the new version
+    - Run `bash scripts/release-integrity-check.sh --post-publish` and require:
+       - package.json version == Marketplace version
+       - git tag exists for package version
+       - GitHub release object exists for the tag

--- a/docs/workflow/learnings.md
+++ b/docs/workflow/learnings.md
@@ -20,6 +20,29 @@
 
 ---
 
+### 2026-03-31 — Release-governance drift needs machine checks, not checklist memory
+
+**Context**: Post-sprint governance audit after FPW v1.4 completion and extension version drift investigation.
+
+**Discovery**: Three release-governance gaps occurred together despite tags and Marketplace publishes succeeding:
+
+1. **Tag/release drift**: Versions `v0.3.13`–`v0.3.16` had git tags and Marketplace artifacts but no GitHub release objects.
+2. **Safety-floor drift**: `MIN_SAFE_DAEMON_VERSION` remained at `20260325.8` while daemon behavior changed in `v20260331.1` (SLEEP mode protocol).
+3. **Bundling drift risk**: The extension bundles daemon files from `resources/` (build artifact) while `resources/` is gitignored, so release correctness depends on running `npm run build` before packaging/publish.
+
+Checklist-only governance was insufficient; these are structural consistency checks and need explicit machine gates.
+
+**Application**:
+- Added `scripts/release-integrity-check.sh` with `--post-publish` mode to require:
+  - `package.json` version has matching git tag
+  - GitHub release object exists for that tag
+  - Marketplace version matches `package.json`
+  - `MIN_SAFE_DAEMON_VERSION` matches daemon `WATCHDOG_VERSION`
+- Added a new docs-integrity guard: `MIN_SAFE_DAEMON_VERSION == WATCHDOG_VERSION`.
+- Updated instruction checklist to require `bash scripts/release-integrity-check.sh --post-publish` for extension behavior changes.
+
+---
+
 ### 2026-03-31 — Sequential Chrome phase isolation eliminates per-publish OOM risk via OS RSS reclaim
 
 **Context**: FPW v1.4 sprint — implementing PRs #130–#134 to address Chrome OOM crashes during Squarespace publish automation on the 6.3 GB Crostini container.

--- a/scripts/docs-integrity-check.sh
+++ b/scripts/docs-integrity-check.sh
@@ -9,6 +9,7 @@
 #   2. .github/copilot-instructions.md test count matches actual
 #   3. CHANGELOG.md has an entry for the current package.json version
 #   4. ci.yml test count comment matches actual
+#   5. installer MIN_SAFE_DAEMON_VERSION matches daemon WATCHDOG_VERSION
 #
 # Usage:
 #   bash scripts/docs-integrity-check.sh          # from repo root
@@ -86,6 +87,20 @@ if [[ -f vscode-extension/package.json && -f vscode-extension/CHANGELOG.md ]]; t
     else
         FAIL "CHANGELOG.md: no entry for v$pkg_version (current package.json version)"
     fi
+fi
+
+# ── Check 5: MIN_SAFE_DAEMON_VERSION matches daemon WATCHDOG_VERSION ───────
+daemon_version="$(grep -m1 -oP '^(?:export\s+)?WATCHDOG_VERSION=\K[0-9]+(?:\.[0-9]+)?' mem-watchdog.sh 2>/dev/null || true)"
+min_safe_version="$(grep -m1 -oP "MIN_SAFE_DAEMON_VERSION = '\K[^']+" vscode-extension/installer.js 2>/dev/null || true)"
+
+if [[ -z "$daemon_version" ]]; then
+    FAIL "mem-watchdog.sh: WATCHDOG_VERSION not found"
+elif [[ -z "$min_safe_version" ]]; then
+    FAIL "installer.js: MIN_SAFE_DAEMON_VERSION not found"
+elif [[ "$daemon_version" != "$min_safe_version" ]]; then
+    FAIL "installer.js: MIN_SAFE_DAEMON_VERSION=$min_safe_version does not match daemon WATCHDOG_VERSION=$daemon_version"
+else
+    PASS "installer.js: MIN_SAFE_DAEMON_VERSION matches daemon WATCHDOG_VERSION ($daemon_version)"
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/scripts/release-integrity-check.sh
+++ b/scripts/release-integrity-check.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# release-integrity-check.sh — enforce release metadata integrity.
+#
+# Modes:
+#   default        Pre-publish checks (local repo state)
+#   --post-publish Includes remote checks (tag/release/Marketplace)
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO"
+
+POST_PUBLISH=0
+if [[ "${1:-}" == "--post-publish" ]]; then
+    POST_PUBLISH=1
+fi
+
+pass=0
+fail=0
+
+PASS() { ((++pass)); echo "  ✓ $1"; }
+FAIL() { ((++fail)); echo "  ✗ $1"; }
+
+pkg_version="$(node -e "process.stdout.write(require('./vscode-extension/package.json').version)")"
+root_daemon_version="$(grep -m1 -oP '^(?:export\s+)?WATCHDOG_VERSION=\K[0-9]+(?:\.[0-9]+)?' mem-watchdog.sh || true)"
+min_safe_version="$(grep -m1 -oP "MIN_SAFE_DAEMON_VERSION = '\K[^']+" vscode-extension/installer.js || true)"
+
+if [[ -n "$pkg_version" ]]; then
+    PASS "package.json version: $pkg_version"
+else
+    FAIL "Could not read vscode-extension/package.json version"
+fi
+
+if grep -qF "[$pkg_version]" vscode-extension/CHANGELOG.md; then
+    PASS "CHANGELOG has entry for v$pkg_version"
+else
+    FAIL "CHANGELOG missing entry for v$pkg_version"
+fi
+
+if [[ -n "$root_daemon_version" && -n "$min_safe_version" && "$root_daemon_version" == "$min_safe_version" ]]; then
+    PASS "MIN_SAFE_DAEMON_VERSION matches daemon WATCHDOG_VERSION ($root_daemon_version)"
+else
+    FAIL "MIN_SAFE_DAEMON_VERSION ($min_safe_version) != daemon WATCHDOG_VERSION ($root_daemon_version)"
+fi
+
+if [[ $POST_PUBLISH -eq 1 ]]; then
+    tag="v$pkg_version"
+
+    if git rev-parse "$tag" >/dev/null 2>&1; then
+        PASS "Git tag exists: $tag"
+    else
+        FAIL "Git tag missing: $tag"
+    fi
+
+    if gh release view "$tag" >/dev/null 2>&1; then
+        PASS "GitHub release exists: $tag"
+    else
+        FAIL "GitHub release missing: $tag"
+    fi
+
+    market_ver=""
+    if command -v npx >/dev/null 2>&1; then
+        market_ver="$(
+            (
+                cd vscode-extension || exit 1
+                npx vsce show CurtisFranks.mem-watchdog-status --json 2>/dev/null
+            ) | grep -m1 -o '"version": "[^"]*"' | cut -d'"' -f4 || true
+        )"
+    fi
+    if [[ -z "$market_ver" ]]; then
+        market_ver="$(curl -s "https://marketplace.visualstudio.com/items?itemName=CurtisFranks.mem-watchdog-status" | grep -o '"version":"[^"]*"' | head -1 | cut -d'"' -f4 || true)"
+    fi
+    if [[ -n "$market_ver" && "$market_ver" == "$pkg_version" ]]; then
+        PASS "Marketplace version matches package.json ($market_ver)"
+    else
+        FAIL "Marketplace version ($market_ver) != package.json ($pkg_version)"
+    fi
+fi
+
+echo ""
+echo "release-integrity: $pass passed, $fail failed"
+(( fail == 0 ))


### PR DESCRIPTION
## SELF_ANNEAL_REPORT
context: post-release
scope: workflow

observation:
- Tags and Marketplace versions existed for v0.3.13-v0.3.16 without corresponding GitHub release objects.
- `MIN_SAFE_DAEMON_VERSION` remained stale after daemon behavior changed in v20260331.1.
- Release correctness relied on operator memory to run build + post-publish verification.

expected_behavior:
- Every shipped extension version has aligned manifest, changelog, git tag, GitHub release object, and Marketplace availability.
- Safety floor (MIN_SAFE) advances with daemon behavior dependencies.
- Post-publish verification is objective and repeatable.

mismatch:
- Governance relied on checklist memory, with no hard gate for metadata continuity or MIN_SAFE alignment.

root_cause: missing guardrail
risk: high

drift_signals:
- metric: carryover
  trend: degrading
  evidence: release metadata gaps persisted across v0.3.13-v0.3.16
- metric: reopen-rate
  trend: degrading
  evidence: repeat release-governance findings across multiple sessions

proposed_changes:
1) file: scripts/release-integrity-check.sh
   change_type: add
   rationale: single executable gate for tag/release/Marketplace/MIN_SAFE consistency
   patch_summary: add pre/post-publish integrity checker with explicit pass/fail output
2) file: scripts/docs-integrity-check.sh
   change_type: edit
   rationale: make MIN_SAFE drift fail in CI/pre-push immediately
   patch_summary: add check requiring MIN_SAFE_DAEMON_VERSION == daemon WATCHDOG_VERSION
3) file: .github/instructions/skill-routing.instructions.md
   change_type: edit
   rationale: make post-publish integrity check explicit in mandatory checklist
   patch_summary: require bash scripts/release-integrity-check.sh --post-publish with 3 pass criteria

verification_plan:
- check: docs-integrity
  pass_condition: 5/5 checks pass including MIN_SAFE alignment
- check: release-integrity (post-publish)
  pass_condition: tag exists, GH release exists, Marketplace version equals package.json, MIN_SAFE equals daemon version

decision:
- apply

missing_evidence:
- none

## Additional updates
- Added learnings entry documenting the failure pattern and controls.
- Added build reference command in copilot instructions.

Closes #144