### PR TITLE
feat(installer): add repo-agnostic managed-window helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Daemon versions use `YYYYMMDD.N` (datestamp + revision).
 
 ## [Unreleased]
 
+### Added
+- **Repo-agnostic managed-window helper** ([#146](https://github.com/chf3198/crostini-mem-watchdog/issues/146)) — added `scripts/mem-watchdog-mode.sh` with `status|sleep|normal|run -- <command>` so any repository/workflow can request watchdog `mode=SLEEP` without embedding custom integration code. Installer now deploys it to `~/.local/bin/mem-watchdog-mode.sh`.
+
+### Changed
+- **Stack-agnostic disposable naming refactor** ([#140](https://github.com/chf3198/crostini-mem-watchdog/issues/140)) — daemon internals now use `kill_disposable_processes()`, `check_disposable_cap()`, `automation_session_active()`, and `DISPOSABLE_COUNT_MAX` naming. Legacy `CHROME_COUNT_MAX` remains accepted as a one-release alias with startup deprecation warning.
+- **Journal token rename (breaking for log parsers)** — `CHROME-EXCESS` → `DISPOSABLE-EXCESS`.
+- **Default automation fallback pattern broadened** — `TIER_DISPOSABLE_PATTERN_AUX` default now includes common Node automation frameworks: `playwright|puppeteer|cypress|selenium-webdriver`.
+- **Managed-window stale-timeout guard** ([#138](https://github.com/chf3198/crostini-mem-watchdog/issues/138)) — `MEM_SLEEP_TIMEOUT_S` (default 300s) now auto-clears stale `mode=SLEEP` signals and logs a warning when the caller fails to clean up.
+
 ## [20260331.1] — 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This watchdog reads only `MemAvailable` and `MemTotal` — both correct on this 
 
 **Language-server protection:** Built-in language servers (HTML, JSON, CSS, Markdown, ESLint) and the Extension Host process are excluded from the helper-kill candidate pool at normal severity. These 80–120 MB processes are subject to VS Code's 5-crash-in-3-minutes permanent death threshold — killing them saves <2% of memory for 2 seconds (they respawn immediately) while permanently disabling language intelligence until a full VS Code restart. Only at true emergency severity (RSS ≥ 3.8 GB) are they considered as last-resort targets.
 
-**Playwright awareness:** When a Playwright MCP session is active (detected via `node.*playwright`), the daemon defers non-critical Chrome kills and skips the `CHROME_COUNT_MAX` cap — Playwright legitimately spawns 5–10 Chrome PIDs. At true emergency severity (≤ 15% free), Chrome is always killed regardless (safety net).
+**Automation awareness:** When an automation session is active (detected via `TIER_DISPOSABLE_PATTERN_AUX`, default `node.*(playwright|puppeteer|cypress|selenium-webdriver)`), the daemon defers non-critical disposable kills and skips the `DISPOSABLE_COUNT_MAX` cap. At true emergency severity (≤ 15% free), disposable processes are always killed regardless (safety net).
 
 - Checks every **2 seconds** (4s was confirmed too slow — missed a 4 GB spike in < 4s on 2026-03-05)
 - **Startup mode**: 0.5 s polling for 90 s after new VS Code PIDs detected — catches extension-host spikes during startup
@@ -110,6 +110,7 @@ crostini-mem-watchdog/
 │   ├── stress-harness.sh        ← Playwright stress test harness
 │   └── stress-playwright.js     ← Playwright automation driver
 ├── scripts/
+│   ├── mem-watchdog-mode.sh   ← repo-agnostic SLEEP/NORMAL mode helper
 │   ├── watchdog-tray.sh         ← optional: yad system tray icon
 │   ├── docs-integrity-check.sh  ← documentation drift check
 │   ├── extension-footprint-advisor.sh ← extension RAM advisor (prototype)
@@ -118,10 +119,10 @@ crostini-mem-watchdog/
     ├── extension.js             ← activate(): install → skill → config → commands → status bar → update check → chat
     ├── installer.js             ← SHA-256 hash-based auto-install/upgrade + downgrade protection + MIN_SAFE guard
     ├── configWriter.js          ← VS Code Settings → ~/.config/mem-watchdog/config.sh
-    ├── commands.js              ← dashboard, preflight, killChrome, restartService
+    ├── commands.js              ← dashboard, preflight, killDisposable, restartService, optimizeMemory, createLowMemProfile
     ├── updateChecker.js         ← GitHub Releases API self-update check (24h throttled)
     ├── skillInstaller.js        ← installs/updates ~/.copilot/skills/mem-watchdog-ops/
-    ├── chatParticipant.js       ← @memwatchdog chat participant: /status, /logs, /tune, /act
+    ├── chatParticipant.js       ← @memwatchdog chat participant: /status, /logs, /tune, /act, /optimize, /lowmem
     ├── utils.js                 ← readMeminfo(), readPsi(), sh(), checkServiceStatus() — shared helpers
     ├── lifecycle.js             ← vscode:uninstall: stop + disable service
     └── scripts/prepare.js       ← vscode:prepublish: bundles daemon files into resources/
@@ -151,6 +152,22 @@ crostini-mem-watchdog/
 | `VSCODE_RSS_EMERG_KB` | `3800000` | ~3.8 GB — VS Code RSS emergency level                  |
 | `NOTIFY_INTERVAL`     | `300`     | Seconds between desktop notifications per severity     |
 
+### Managed Protection Window (Repo-Agnostic)
+
+Use the installed helper script to safely run any automation command in a watchdog-managed SLEEP window (no repo-specific integration required):
+
+```bash
+~/.local/bin/mem-watchdog-mode.sh run -- node scripts/mcp/local_capture_test.js
+```
+
+Other commands:
+
+```bash
+~/.local/bin/mem-watchdog-mode.sh status
+~/.local/bin/mem-watchdog-mode.sh sleep
+~/.local/bin/mem-watchdog-mode.sh normal
+```
+
 ### Tuning for Your RAM
 
 | Total RAM        | `VSCODE_RSS_WARN_KB` | `VSCODE_RSS_EMERG_KB` |
@@ -168,7 +185,7 @@ All 4 gates must pass before any change is published:
 
 ```bash
 bash tests/test-watchdog.sh              # 18 bash tests (~3 s) — service, OOM scores, PSI, SwapFree safety, SIGTERM
-cd vscode-extension && npm test    # 146 JS unit tests (~1 s) — extension state machine, activation singleton, pileup guard, utils
+cd vscode-extension && npm test    # 146 JS unit tests (~1 s) — extension state machine, activation singleton, low-memory profile guidance, utils
 bash -n mem-watchdog.sh            # bash syntax check
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh scripts/watchdog-tray.sh install.sh
 ```

--- a/docs/workflow/learnings.md
+++ b/docs/workflow/learnings.md
@@ -20,6 +20,72 @@
 
 ---
 
+### 2026-03-31 — Managed-window control must be repo-agnostic, not integration-specific
+
+**Context**: Stabilizing automation sessions after repeated crashes where one repository had a custom managed-window integration but other workflows did not.
+
+**Discovery**: The daemon-level `mode=SLEEP` protocol is globally useful, but relying on per-repository wrappers creates drift and gaps. The robust pattern is a repo-agnostic helper command that lives with mem-watchdog itself and wraps arbitrary commands in a guaranteed `SLEEP → command → NORMAL` lifecycle, including signal-safe cleanup.
+
+**Application**:
+- Added `scripts/mem-watchdog-mode.sh` with `status|sleep|normal|run -- <command>`.
+- Installer now deploys `~/.local/bin/mem-watchdog-mode.sh` so any repo can use the same control surface.
+- Documentation now points users to the helper as the default managed-window entry point.
+
+---
+
+### 2026-03-31 — VS Code low-memory profiles are feasible, but only as guided automation
+
+**Context**: Implementing issue #128 — low-memory profile support in the VS Code extension.
+
+**Discovery**: VS Code exposes stable built-in commands for profile creation/switching (`workbench.profiles.actions.createFromCurrentProfile`, `workbench.profiles.actions.switchProfile`) and extension listing (`workbench.extensions.action.showExtensionsWithIds`), but not a clean one-shot public API to clone a profile and disable a curated extension set programmatically. The workable path is guided automation: create/switch the profile with built-in profile commands, then disable recommended heavy extensions in the *current* profile via extension editor actions. The key enabling fact is that extension enablement is profile-scoped — global disablement storage lives in `StorageScope.PROFILE`, not one machine-wide toggle shared across all profiles.
+
+**Application**:
+- Low-memory profile UX should be implemented as a guided workflow, not a fake fully-automatic API abstraction.
+- It is safe to recommend disabling heavy extensions inside a dedicated profile because the enablement state stays isolated to that profile.
+- `/memwatchdog optimize` should recommend a LowMem profile when settings are already tuned but installed extension weight is still high; settings tuning alone does not solve extension-host baseline RSS.
+
+---
+
+### 2026-03-31 — Inotify pressure is currently low; install-time excludes matter more than runtime sysctl tuning
+
+**Context**: Completing issue #123 — measuring current inotify watch pressure and determining a safe watch-limit posture for this system.
+
+**Discovery**: A live probe on the active development session found only 34 inotify file descriptors and 389 total watches after the optimizer exclusions landed. The container reports `fs.inotify.max_user_watches=1048576`, but runtime attempts to lower the value via `sudo -n sysctl fs.inotify.max_user_watches=...` fail with `permission denied on key "fs.inotify.max_user_watches"` in this Crostini environment. That means the valuable control surface here is not runtime daemon tuning — it is install-time `sysctl.d` guidance plus aggressive `files.watcherExclude` patterns that prevent watch creation in the first place.
+
+**Application**:
+- Keep the optimizer's aggressive watcher excludes as the primary inotify memory reduction mechanism.
+- Keep the install-time `sysctl.d` write at the conservative floor of `16384`; it is far above the currently observed 389-watch workload while still much lower than the host default.
+- Do not add daemon-time `sysctl` mutation logic for inotify; this environment blocks it and the current optimized watch count is already small.
+
+---
+
+### 2026-03-31 — `prlimit --as` is the wrong containment primitive for Electron/VS Code
+
+**Context**: Completing issue #122 — evaluating `prlimit --as` as a proactive daemon control for VS Code.
+
+**Discovery**: Live `/proc/PID/status` baselines show Electron/VS Code processes reserving enormous virtual address spaces on this machine — multiple `code` PIDs report `VmSize` around 1.46 TB while RSS is only 100–630 MB. `prlimit --pid <code-pid> --as` confirms the current RLIMIT_AS is unlimited, and any practical cap in the 4–8 GB range would immediately sit far below the already-reserved virtual address space. That means `RLIMIT_AS` does not track the resource we actually care about (RSS); it would either do nothing useful if set in the terabyte range or break VS Code instantly if set in the gigabyte range.
+
+**Application**:
+- Reject `prlimit --as` as a daemon containment mechanism for this repo.
+- Close follow-on work that depends on dynamic RLIMIT_AS ceilings; it conflicts with the current outward-facing policy and is technically mismatched to Electron's address-space behavior.
+- Use MemAvailable/PSI, V8 heap tuning, extension-weight reduction, and targeted browser containment instead of process-tree RLIMIT_AS caps.
+
+---
+
+### 2026-03-31 — `memory.force_empty` can block for minutes; reclaim must be bounded
+
+**Context**: Returning to active work in frankspressurewashing caused a VS Code freeze during a Playwright-heavy window. The watchdog journal showed Stage 4 kill activity at 15:03 followed by a long period with no watchdog progress.
+
+**Discovery**: `cgroup_reclaim()` used synchronous `echo 0 | sudo -n tee memory.force_empty` with no timeout and no spacing between attempts. A second reclaim call at 15:03:22 stayed open until 15:16:37 (13m15s), creating a watchdog blind spot where the main loop could not evaluate new pressure conditions. This was not a kernel OOM event; it was control-path blocking in the daemon itself.
+
+**Application**:
+- Added bounded reclaim writes using `timeout ${RECLAIM_TIMEOUT_S}s` for both `memory.reclaim` (v2) and `memory.force_empty` (v1).
+- Added `RECLAIM_MIN_INTERVAL_S` guard + `_last_reclaim_action_time` to prevent reclaim storms and back-to-back reclaim calls.
+- Updated Stage 3 PSI-only logging to distinguish reclaim applied vs reclaim skipped/unavailable so post-incident forensics are accurate.
+- Bumped daemon `WATCHDOG_VERSION` to `20260331.2` and extension `MIN_SAFE_DAEMON_VERSION` to match.
+
+---
+
 ### 2026-03-31 — Release-governance drift needs machine checks, not checklist memory
 
 **Context**: Post-sprint governance audit after FPW v1.4 completion and extension version drift investigation.

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,22 @@ run()     {
     eval "$@"
   fi
 }
+  # ── Step 3d: inotify watch cap (optional, requires sudo) ─────────────────────
+  # Issue #127: reduce kernel memory pinned by excessive inotify watches.
+  # Conservative default for this host: 16384 watches.
+  INOTIFY_SYSCTL="/etc/sysctl.d/90-mem-watchdog.conf"
+  INOTIFY_VALUE="16384"
+  if ! $DRY_RUN && sudo -n true 2>/dev/null; then
+    echo "Step 3d — inotify watch cap (sudo available)"
+    sudo mkdir -p /etc/sysctl.d
+    printf 'fs.inotify.max_user_watches=%s\n' "$INOTIFY_VALUE" | sudo tee "$INOTIFY_SYSCTL" >/dev/null
+    sudo sysctl -q -w "fs.inotify.max_user_watches=${INOTIFY_VALUE}" >/dev/null 2>&1 || true
+    info "inotify cap configured → ${INOTIFY_SYSCTL} (max_user_watches=${INOTIFY_VALUE})"
+  else
+    warning "Skipping inotify cap config — sudo not available or dry-run"
+    warning "To apply manually: echo 'fs.inotify.max_user_watches=${INOTIFY_VALUE}' | sudo tee '${INOTIFY_SYSCTL}'"
+  fi
+
 
 echo ""
 echo "┌─────────────────────────────────────────────────────┐"
@@ -67,7 +83,10 @@ echo "Step 1/4 — Install daemon"
 run "mkdir -p '${INSTALL_BIN}'"
 run "cp '${SCRIPT_DIR}/mem-watchdog.sh' '${INSTALL_BIN}/mem-watchdog.sh'"
 run "chmod +x '${INSTALL_BIN}/mem-watchdog.sh'"
+run "cp '${SCRIPT_DIR}/scripts/mem-watchdog-mode.sh' '${INSTALL_BIN}/mem-watchdog-mode.sh'"
+run "chmod +x '${INSTALL_BIN}/mem-watchdog-mode.sh'"
 info "mem-watchdog.sh → ${INSTALL_BIN}/mem-watchdog.sh"
+info "mem-watchdog-mode.sh → ${INSTALL_BIN}/mem-watchdog-mode.sh"
 
 # ── Step 2: Install service unit ──────────────────────────────────────────────
 echo "Step 2/4 — Install systemd user service"

--- a/scripts/mem-watchdog-mode.sh
+++ b/scripts/mem-watchdog-mode.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# mem-watchdog-mode.sh — repo-agnostic managed-window control
+#
+# Purpose:
+#   Control ~/.config/mem-watchdog/mode for automation sessions.
+#   - sleep   => write SLEEP (daemon defers kill/reclaim actions)
+#   - normal  => clear mode file (resume normal watchdog behavior)
+#   - status  => print current mode
+#   - run ... => run a command inside a managed SLEEP window
+
+set -euo pipefail
+
+MODE_FILE="${XDG_CONFIG_HOME:-${HOME}/.config}/mem-watchdog/mode"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  mem-watchdog-mode.sh status
+  mem-watchdog-mode.sh sleep
+  mem-watchdog-mode.sh normal
+  mem-watchdog-mode.sh run -- <command> [args...]
+
+Examples:
+  mem-watchdog-mode.sh sleep
+  mem-watchdog-mode.sh normal
+  mem-watchdog-mode.sh run -- node scripts/capture.js
+EOF
+}
+
+set_sleep_mode() {
+  mkdir -p "$(dirname "$MODE_FILE")"
+  printf 'SLEEP\n' > "$MODE_FILE"
+  echo "mode=SLEEP"
+}
+
+set_normal_mode() {
+  rm -f "$MODE_FILE"
+  echo "mode=NORMAL"
+}
+
+show_status() {
+  local mode=''
+  if [[ -f "$MODE_FILE" ]]; then
+    read -r mode < "$MODE_FILE" 2>/dev/null || mode=''
+  fi
+
+  if [[ "$mode" == 'SLEEP' ]]; then
+    echo "mode=SLEEP"
+  else
+    echo "mode=NORMAL"
+  fi
+}
+
+run_managed_window() {
+  if [[ "$1" == '--' ]]; then
+    shift
+  fi
+
+  if (( $# == 0 )); then
+    echo "ERROR: run requires a command" >&2
+    usage
+    return 2
+  fi
+
+  set_sleep_mode >/dev/null
+
+  cleanup_mode() {
+    set_normal_mode >/dev/null || true
+  }
+
+  trap cleanup_mode EXIT INT TERM
+  "$@"
+}
+
+cmd="${1:-}"
+
+case "$cmd" in
+  status)
+    show_status
+    ;;
+  sleep)
+    set_sleep_mode
+    ;;
+  normal)
+    set_normal_mode
+    ;;
+  run)
+    shift
+    run_managed_window "$@"
+    ;;
+  -h|--help|'')
+    usage
+    ;;
+  *)
+    echo "ERROR: unknown command: $cmd" >&2
+    usage
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add `scripts/mem-watchdog-mode.sh` with `status|sleep|normal|run -- <command>`
- install helper to `~/.local/bin/mem-watchdog-mode.sh` via installer
- document repo-agnostic managed-window usage in root README
- update daemon changelog and workflow learnings

## Why
Repo-specific wrappers are brittle. Managed-window control belongs in mem-watchdog itself so all repos can use one command surface.

Closes #146

## Validation
- `bash tests/test-watchdog.sh`
- `bash -n mem-watchdog.sh`
- `shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh scripts/watchdog-tray.sh install.sh scripts/mem-watchdog-mode.sh`
- `cd vscode-extension && npm test`
- `bash scripts/docs-integrity-check.sh`
- functional sanity checks:
  - `scripts/mem-watchdog-mode.sh status`
  - `scripts/mem-watchdog-mode.sh sleep && scripts/mem-watchdog-mode.sh normal`
  - `scripts/mem-watchdog-mode.sh run -- <cmd>` clears mode on exit
