### PR TITLE
feat(extension): replace modal kill-approval prompt with VS Code-native QuickPick (v0.3.21)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@ the non-negotiable invariants, and how to run the gate suite before opening a PR
 git clone https://github.com/chf3198/crostini-mem-watchdog.git
 cd crostini-mem-watchdog/vscode-extension
 npm ci           # install devDependencies (no prod deps)
-npm test         # 189 unit tests — must exit 0
+npm test         # 191 unit tests — must exit 0
 ```
 
 > **Important:** `npm test` must be run from inside `vscode-extension/`, not from
@@ -53,7 +53,7 @@ bash -n mem-watchdog.sh
 # 3. ShellCheck — SC1091 (source) and SC2317 (unreachable) are intentionally suppressed
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh scripts/watchdog-tray.sh install.sh
 
-# 4. JS unit tests (189 tests, ~1 s) — must run from vscode-extension/
+# 4. JS unit tests (191 tests, ~1 s) — must run from vscode-extension/
 cd vscode-extension && npm test
 
 # 5. Documentation drift check
@@ -194,7 +194,7 @@ journalctl --user -u mem-watchdog -f
 # Build and publish VS Code extension
 cd vscode-extension
 npm run build                     # populate resources/ for local dev/testing
-npm test                          # 189 JS unit tests
+npm test                          # 191 JS unit tests
 npm run test:coverage             # + c8 V8 coverage report
 npm run test:stress               # stress scenarios
 npx vsce package                  # → mem-watchdog-status-x.y.z.vsix

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@ All five checks must exit 0 before this PR is ready for review.
 - [ ] `bash tests/test-watchdog.sh` — 20 bash tests (run from repo root)
 - [ ] `bash -n mem-watchdog.sh` — bash syntax check
 - [ ] `shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh scripts/watchdog-tray.sh install.sh`
-- [ ] `cd vscode-extension && npm test` — 189 JS unit tests
+- [ ] `cd vscode-extension && npm test` — 191 JS unit tests
 - [ ] `bash scripts/docs-integrity-check.sh` — documentation drift check
 
 ## Documentation coverage (local + public-facing)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,7 +84,7 @@ EXPLORE → PLAN → IMPLEMENT → GATE → REFLECT → COMMIT
 bash tests/test-watchdog.sh                                                          # 20 bash tests, ~3s
 bash -n mem-watchdog.sh                                                        # syntax check
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh scripts/watchdog-tray.sh install.sh
-cd vscode-extension && npm test                                                # 189 JS unit tests, ~1s
+cd vscode-extension && npm test                                                # 191 JS unit tests, ~1s
 bash scripts/docs-integrity-check.sh                                           # docs drift check
 ```
 
@@ -97,7 +97,7 @@ bash scripts/docs-integrity-check.sh                                           #
 ```bash
 cd vscode-extension
 npm run build              # populate resources/ for dev (gitignored; required before vsce package)
-npm test                   # 189 unit tests via node:test (~1s)
+npm test                   # 191 unit tests via node:test (~1s)
 npm run test:coverage      # + c8 V8 lcov output
 npm run test:stress        # pileup guard + event-loop lag + heap scenarios
 npx vsce package           # → mem-watchdog-status-x.y.z.vsix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@
 #
 #   bash tests/test-watchdog.sh   # on your Crostini machine
 #
-# The CI gate covers: daemon syntax, shellcheck, all 189 JS unit tests, and docs integrity.
+# The CI gate covers: daemon syntax, shellcheck, all 191 JS unit tests, and docs integrity.
 # ──────────────────────────────────────────────────────────────────────────────
 
 name: CI
@@ -74,7 +74,7 @@ jobs:
         run: npm ci
         working-directory: vscode-extension
 
-      - name: npm test (189 unit tests)
+      - name: npm test (191 unit tests)
         run: npm test
         working-directory: vscode-extension
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Daemon versions use `YYYYMMDD.N` (datestamp + revision).
 
 ## [Unreleased]
 
+## Extension v0.3.21 — 2026-04-05
+
+### Changed
+- **Kill-approval UX redesigned with VS Code-native QuickPick** ([#160](https://github.com/chf3198/crostini-mem-watchdog/issues/160)) — replaced `showWarningMessage({ modal: true })` with `createQuickPick()`. Live metrics placeholder, per-item `detail` tooltips, human-readable reason translation (`humanizeReason()`), and a "What does this mean?" help item. No daemon changes.
+
 ### Added
 - **Interactive non-critical kill approval handshake** ([#157](https://github.com/chf3198/crostini-mem-watchdog/issues/157)) — daemon now supports an operator-in-the-loop gate for non-critical `kill_disposable_processes()` actions via `~/.config/mem-watchdog/kill-approval-request` and `kill-approval-response`. When enabled, the daemon requests approval, waits for extension response up to `INTERACTIVE_KILL_PROMPT_TTL_S`, and honors `defer` responses with bounded cooldown (`INTERACTIVE_KILL_DEFER_DEFAULT_S`). Critical paths remain ungated.
 - **Repo-agnostic managed-window helper** ([#146](https://github.com/chf3198/crostini-mem-watchdog/issues/146)) — added `scripts/mem-watchdog-mode.sh` with `status|sleep|normal|run -- <command>` so any repository/workflow can request watchdog `mode=SLEEP` without embedding custom integration code. Installer now deploys it to `~/.local/bin/mem-watchdog-mode.sh`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: PolyForm NC](https://img.shields.io/badge/License-PolyForm%20NC%201.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-ChromeOS%20Crostini-4285f4)](https://chromeos.dev/en/linux)
 [![Tests](https://img.shields.io/badge/bash-20%2F20-brightgreen)](tests/test-watchdog.sh)
-[![Tests](https://img.shields.io/badge/js-189%2F189-brightgreen)](vscode-extension/package.json)
+[![Tests](https://img.shields.io/badge/js-191%2F191-brightgreen)](vscode-extension/package.json)
 
 _`earlyoom` hard-crashes on Crostini (exit 104, every 3 seconds, zero protection). This replaces it with a VS Code-aware watchdog that kills Chrome before the kernel OOM-kills VS Code._
 
@@ -207,7 +207,7 @@ All 4 gates must pass before any change is published:
 
 ```bash
 bash tests/test-watchdog.sh              # 20 bash tests (~3 s) — service, OOM scores, PSI, RSS circuit-breaker policy, SwapFree safety, startup chat-footprint warning scan, SIGTERM
-cd vscode-extension && npm test    # 189 JS unit tests (~1 s) — continuity rescue flow (including cross-workspace preemptive archival), extension state machine, activation singleton, low-memory profile guidance, utils
+cd vscode-extension && npm test    # 191 JS unit tests (~1 s) — continuity rescue flow (including cross-workspace preemptive archival), extension state machine, activation singleton, low-memory profile guidance, utils
 bash -n mem-watchdog.sh            # bash syntax check
 shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh scripts/watchdog-tray.sh install.sh
 ```

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.3.21] — 2026-04-05
+
+### Changed
+- **Kill-approval prompt redesigned with VS Code-native QuickPick** ([#160](https://github.com/chf3198/crostini-mem-watchdog/issues/160)) — replaced `showWarningMessage({ modal: true })` (flat newline-joined string, non-functional `MessageItem.tooltip`) with `createQuickPick()`. The new panel is dark/light theme-aware and shows: a title, a placeholder with live metrics (% free · MB avail · RSS · PSI · trend sparkline), and three labeled items each with a `detail` line acting as an in-context tooltip. Daemon reason tokens (e.g. `ACCEL rss_delta=412MB`) are translated to human-readable English by a new `humanizeReason()` helper. A **"What does this mean?"** third item opens a full explanation notification, then defaults to Allow to keep the daemon unblocked. Dismiss / Escape still defaults to Allow (safety posture preserved).
+
 ## [0.3.20] — 2026-04-05
 
 ### Added

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -190,9 +190,9 @@ Commercial use requires a paid license. See [COMMERCIAL-LICENSE.md](https://gith
 git clone https://github.com/chf3198/crostini-mem-watchdog.git
 cd crostini-mem-watchdog/vscode-extension
 npm run build          # populate resources/ from repo root
-npm test               # 189 JS unit tests via node:test (zero-install)
+npm test               # 191 JS unit tests via node:test (zero-install)
 npm run test:coverage  # same + c8 V8 coverage report
 npm run test:stress    # stress scenarios: pileup guard, EL lag, heap usage
 ```
 
-189 unit tests covering `readMeminfo`/`readPsi`/`sh()`/`checkServiceStatus()` plus thematic state helpers (`readWatchdogMode()`, `readRssThresholds()`, `determineState()`, `stateDescription()`), chat continuity archival/resume generation (including preemptive inactive-workspace rescue), low-memory profile classification/guidance, config validation, command handlers, installer decision logic, `activate()` singleton lifecycle, the `update()` state machine + pileup guard, update checker (version comparison, throttling, dismissal), installer MIN_SAFE_DAEMON_VERSION guard, installer downgrade protection (export-prefix version parsing), skill installer (install/update/skip), and `@memwatchdog` chat participant (status, logs, tune, optimize, lowmem, rescue, followups, API availability guard).
+191 unit tests covering `readMeminfo`/`readPsi`/`sh()`/`checkServiceStatus()` plus thematic state helpers (`readWatchdogMode()`, `readRssThresholds()`, `determineState()`, `stateDescription()`), chat continuity archival/resume generation (including preemptive inactive-workspace rescue), low-memory profile classification/guidance, config validation, command handlers, installer decision logic, `activate()` singleton lifecycle, the `update()` state machine + pileup guard, update checker (version comparison, throttling, dismissal), installer MIN_SAFE_DAEMON_VERSION guard, installer downgrade protection (export-prefix version parsing), skill installer (install/update/skip), and `@memwatchdog` chat participant (status, logs, tune, optimize, lowmem, rescue, followups, API availability guard).

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -118,6 +118,35 @@ function buildSparkline(points) {
     }).join('');
 }
 
+/**
+ * Convert a raw daemon reason token into a human-readable English phrase.
+ * Daemon tokens (e.g. "ACCEL rss_delta=412MB") are intentionally terse for
+ * journal logging; the extension translates them into operator-friendly text.
+ *
+ * @param {string} raw
+ * @returns {string}
+ */
+function humanizeReason(raw) {
+    if (!raw) { return 'Memory pressure detected'; }
+    if (/ACCEL|rss_delta/i.test(raw))      { return 'VS Code RSS is rising fast'; }
+    if (/WARN|rss_warn/i.test(raw))         { return 'VS Code RSS near warning threshold'; }
+    if (/PSI|psi_full/i.test(raw))          { return 'Memory pressure index is elevated'; }
+    if (/DISPOSABLE|disposable/i.test(raw)) { return 'Too many idle browser processes'; }
+    if (/BURST|burst/i.test(raw))           { return 'Process count spiking rapidly'; }
+    return raw;
+}
+
+/**
+ * Show a VS Code-native QuickPick panel requesting operator approval before
+ * a non-critical daemon intervention.  Replaces the previous
+ * showWarningMessage({ modal: true }) call which:
+ *   – dumped all content as a raw newline-joined string
+ *   – silently ignored MessageItem.tooltip
+ *   – used jargon labels with no in-context explanation
+ *
+ * Dismiss / Escape defaults to 'allow' to preserve the safety posture.
+ * Emergency-path actions are never gated by this prompt.
+ */
 async function maybeHandleKillApprovalPrompt() {
     if (_killApprovalInFlight) { return; }
     const req = readKillApprovalRequest();
@@ -130,49 +159,104 @@ async function maybeHandleKillApprovalPrompt() {
             .getConfiguration('memWatchdog')
             .get('interactiveKillApproval.deferSeconds', 120);
         const deferSeconds = Math.max(30, Math.min(900, Math.floor(Number(deferSecondsCfg) || 120)));
-        const deferLabel = deferSeconds >= 60
-            ? `Hold fire (${Math.round(deferSeconds / 60)} min)`
-            : `Hold fire (${deferSeconds}s)`;
 
-        const trend = buildSparkline(_memTrend);
-        const pct = Number.isFinite(req.pct) ? req.pct : null;
-        const availMB = Number.isFinite(req.mem_available_kb) ? Math.round(req.mem_available_kb / 1024) : null;
-        const rssMB = Number.isFinite(req.vscode_rss_kb) ? Math.round(req.vscode_rss_kb / 1024) : null;
-        const psi = Number.isFinite(req.psi_full_x100)
+        const trend    = buildSparkline(_memTrend);
+        const pct      = Number.isFinite(req.pct)              ? req.pct                                   : null;
+        const availMB  = Number.isFinite(req.mem_available_kb) ? Math.round(req.mem_available_kb / 1024)  : null;
+        const rssMB    = Number.isFinite(req.vscode_rss_kb)    ? Math.round(req.vscode_rss_kb / 1024)     : null;
+        const psi      = Number.isFinite(req.psi_full_x100)
             ? `${Math.floor(req.psi_full_x100 / 100)}.${String(req.psi_full_x100 % 100).padStart(2, '0')}`
             : null;
 
-        const detail = [
-            pct === null ? null : `free=${pct}%`,
-            availMB === null ? null : `avail=${availMB}MB`,
-            rssMB === null ? null : `rss=${rssMB}MB`,
-            psi === null ? null : `psi_full=${psi}%`,
-        ].filter(Boolean).join(' · ');
+        // Placeholder: live metrics line shown beneath the title in the QuickPick
+        const metricParts = [
+            pct     !== null ? `${pct}% free`      : null,
+            availMB !== null ? `${availMB} MB avail` : null,
+            rssMB   !== null ? `${rssMB} MB RSS`    : null,
+            psi     !== null ? `PSI ${psi}%`        : null,
+        ].filter(Boolean);
+        const metricsLine = metricParts.length > 0
+            ? metricParts.join('  \u00b7  ')   // middle-dot separator
+            : 'Memory pressure detected';
 
-        const msg = [
-            'Mem Watchdog requests approval for a non-critical disposable-process intervention.',
-            req.reason ? `Reason: ${req.reason}` : null,
-            detail || null,
-            `Memory trend (recent VS Code RSS): ${trend}`,
-            'Sic \'em now: allow one immediate non-critical cleanup action.',
-            `Hold fire: defer non-critical cleanup for ${deferSeconds >= 60 ? `${Math.round(deferSeconds / 60)} minute(s)` : `${deferSeconds} second(s)`}.`,
-            'Allow now, or defer this action for a short cooldown window.',
-        ].filter(Boolean).join('\n');
+        const reasonText    = humanizeReason(req.reason);
+        const deferMinLabel = deferSeconds >= 60
+            ? `${Math.round(deferSeconds / 60)} min`
+            : `${deferSeconds}s`;
+        const deferDetailTime = deferSeconds >= 60
+            ? `${Math.round(deferSeconds / 60)} minutes`
+            : `${deferSeconds} seconds`;
 
-        const allowBtn = {
-            title: 'Sic \'em now',
-            tooltip: 'Allow this one non-critical intervention now. Emergency actions are always allowed regardless.',
-        };
-        const deferBtn = {
-            title: deferLabel,
-            tooltip: `Defer non-critical interventions for ${deferSeconds} seconds. Emergency safeguards remain active.`,
-        };
-        const choice = await vscode.window.showWarningMessage(msg, { modal: true }, allowBtn, deferBtn);
-        if (choice === deferBtn || choice?.title === deferBtn.title) {
-            writeKillApprovalDecision(req.id, 'defer', deferSeconds);
+        const ALLOW = 'allow';
+        const DEFER = 'defer';
+        const HELP  = 'help';
+
+        const choice = await new Promise((resolve) => {
+            const qp = vscode.window.createQuickPick();
+            qp.title          = '$(shield) Mem Watchdog \u2014 Intervention Approval';
+            qp.placeholder    = `${metricsLine}   trend: ${trend}`;
+            qp.ignoreFocusOut = true;
+
+            const allowItem = {
+                label:      '$(play) Allow intervention',
+                description: reasonText,
+                detail:     'Sends SIGTERM to one disposable process (e.g. an idle Chrome renderer). ' +
+                            'Emergency safety actions are always allowed regardless of this choice.',
+                alwaysShow: true,
+                value:      ALLOW,
+            };
+            const deferItem = {
+                label:      `$(clock) Hold fire \u2014 ${deferMinLabel}`,
+                description: `Pause non-critical cleanup for ${deferDetailTime}`,
+                detail:     `Non-critical cleanup is paused for ${deferDetailTime}. ` +
+                            'If RSS crosses the emergency threshold during that window, ' +
+                            'the watchdog acts immediately regardless.',
+                alwaysShow: true,
+                value:      DEFER,
+            };
+            const helpItem = {
+                label:      '$(question) What does this mean?',
+                description: 'Show explanation',
+                detail:     'Learn what this prompt is, why you\'re seeing it, and what each choice does.',
+                alwaysShow: true,
+                value:      HELP,
+            };
+            qp.items = [allowItem, deferItem, helpItem];
+
+            // _resolved prevents double-resolution: onDidAccept resolves first,
+            // then the hide() call inside onDidAccept triggers onDidHide, which
+            // must not re-resolve with the default 'allow'.
+            let _resolved = false;
+            const done = (v) => { if (!_resolved) { _resolved = true; resolve(v); } };
+
+            qp.onDidAccept(() => {
+                const sel = qp.selectedItems[0];
+                done(sel ? sel.value : ALLOW); // resolve before hiding
+                qp.hide();
+            });
+            qp.onDidHide(() => {
+                qp.dispose();
+                done(ALLOW); // Escape → allow; no-op if already resolved by accept
+            });
+
+            qp.show();
+        });
+
+        if (choice === HELP) {
+            vscode.window.showInformationMessage(
+                'Mem Watchdog monitors VS Code memory usage and intervenes before the container OOM killer fires. ' +
+                'This prompt appears when RSS is approaching warning thresholds and a non-critical cleanup action is ready. ' +
+                '"Allow intervention" sends SIGTERM to one disposable process (e.g. an idle Chrome renderer). ' +
+                '"Hold fire" pauses non-critical actions temporarily — emergency actions are never gated by this prompt. ' +
+                'Dismissing (Escape) defaults to Allow to preserve the safety posture.'
+            );
+            // After showing help, default to allow to unblock the daemon.
+            writeKillApprovalDecision(req.id, ALLOW);
+        } else if (choice === DEFER) {
+            writeKillApprovalDecision(req.id, DEFER, deferSeconds);
         } else {
-            // Default to allow when dismissed to preserve safety posture.
-            writeKillApprovalDecision(req.id, 'allow');
+            // ALLOW and any unexpected value
+            writeKillApprovalDecision(req.id, ALLOW);
         }
         _lastKillApprovalId = req.id;
     } catch (err) {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "mem-watchdog-status",
   "displayName": "Mem Watchdog",
   "description": "Prevents VS Code from being OOM-killed on ChromeOS Crostini — auto-installs a systemd memory watchdog daemon that kills Chrome/Playwright before the kernel kills VS Code.",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "publisher": "CurtisFranks",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {

--- a/vscode-extension/test/helpers/mockVscode.js
+++ b/vscode-extension/test/helpers/mockVscode.js
@@ -29,13 +29,22 @@ const mockWindow = {
     _warnMessages:  [],
     _infoChoices:   [],   // the button label the user "clicked" (set per-test)
     _warnChoices:   [],   // same pattern for showWarningMessage button selection
+    // ── QuickPick simulation ─────────────────────────────────────────────────
+    // Push 'allow' | 'defer' | 'help' | null (null = Escape/dismiss) before
+    // the test that triggers maybeHandleKillApprovalPrompt.  The mock's show()
+    // pulls one entry per createQuickPick() call and fires the appropriate
+    // onDidAccept / onDidHide handler synchronously, exactly as VS Code does.
+    _quickPickChoices: [],
+    _lastQuickPick:    null,
 
     reset() {
-        this._infoMessages  = [];
-        this._errorMessages = [];
-        this._warnMessages  = [];
-        this._infoChoices   = [];
-        this._warnChoices   = [];
+        this._infoMessages     = [];
+        this._errorMessages    = [];
+        this._warnMessages     = [];
+        this._infoChoices      = [];
+        this._warnChoices      = [];
+        this._quickPickChoices = [];
+        this._lastQuickPick    = null;
     },
 
     showInformationMessage(msg, ...rest) {
@@ -61,6 +70,56 @@ const mockWindow = {
     },
     createStatusBarItem() {
         return { text: '', color: '', tooltip: '', show() {}, dispose() {} };
+    },
+    /**
+     * QuickPick mock — mirrors the VS Code createQuickPick() contract.
+     *
+     * Behaviour in show():
+     *   • If _quickPickChoices has an entry whose value matches a QuickPickItem's
+     *     .value property, selectedItems is set and onDidAccept fires (then
+     *     onDidHide fires via qp.hide() called inside the real accept handler).
+     *   • null or no entry → Escape / dismiss → onDidHide fires directly.
+     *
+     * The _resolved guard in the real extension code prevents double-resolution,
+     * so firing both handlers in sequence is safe and correctly mirrors VS Code.
+     */
+    createQuickPick() {
+        const self = mockWindow;
+        const qp = {
+            title:          '',
+            placeholder:    '',
+            ignoreFocusOut: false,
+            items:          [],
+            selectedItems:  [],
+            _onAccept:      null,
+            _onHide:        null,
+            onDidAccept(fn) { qp._onAccept = fn; return { dispose() {} }; },
+            onDidHide(fn)   { qp._onHide   = fn; return { dispose() {} }; },
+            hide()   { if (qp._onHide) { qp._onHide(); } },
+            dispose() {},
+            show() {
+                const choice = self._quickPickChoices.shift();
+                if (choice !== undefined && choice !== null) {
+                    const found = qp.items.find((i) => i.value === choice);
+                    if (found) {
+                        qp.selectedItems = [found];
+                        // Accept fires first; the real onDidAccept calls qp.hide()
+                        // which triggers onDidHide — same sequence here.
+                        if (qp._onAccept) { qp._onAccept(); }
+                        // onDidHide triggered by hide() inside the accept handler;
+                        // nothing more to do here.
+                    } else {
+                        // Unknown value → treat as dismiss
+                        if (qp._onHide) { qp._onHide(); }
+                    }
+                } else {
+                    // null or nothing in queue → Escape / dismiss
+                    if (qp._onHide) { qp._onHide(); }
+                }
+            },
+        };
+        self._lastQuickPick = qp;
+        return qp;
     },
     visibleTextEditors: [],
     showTextDocument(doc) {

--- a/vscode-extension/test/unit/extension.test.js
+++ b/vscode-extension/test/unit/extension.test.js
@@ -342,7 +342,7 @@ describe('update() — tooltip IPC cache', () => {
 describe('update() — interactive kill approval prompt', () => {
     beforeEach(() => { resetState(); resetStateCache(); });
 
-    test('writes allow decision when operator chooses "Sic \'em now"', async () => {
+    test('writes allow decision when operator selects allow item', async () => {
         resetState({
             killRequest: {
                 id: 'req-1',
@@ -356,18 +356,28 @@ describe('update() — interactive kill approval prompt', () => {
                 vscode_rss_kb: 3600000,
             },
         });
-        mockWindow._warnChoices.push("Sic 'em now");
+        mockWindow._quickPickChoices.push('allow');
 
         const item = makeItem();
         await update(item);
 
-        assert.ok(mockWindow._warnMessages.length >= 1, 'modal warning prompt should be shown');
-        assert.ok(mockWindow._warnMessages[0].includes("Sic 'em now:"), 'modal should explain allow action');
-        assert.ok(mockWindow._warnMessages[0].includes('Hold fire:'), 'modal should explain defer action');
+        assert.ok(mockWindow._lastQuickPick, 'createQuickPick() should have been called');
+        assert.ok(
+            mockWindow._lastQuickPick.title.includes('Mem Watchdog'),
+            `QuickPick title should include 'Mem Watchdog', got: "${mockWindow._lastQuickPick.title}"`
+        );
+        assert.ok(
+            mockWindow._lastQuickPick.items.length >= 3,
+            `QuickPick should have at least 3 items, got: ${mockWindow._lastQuickPick.items.length}`
+        );
+        // Allow item should carry the human-readable reason in its description
+        const allowItem = mockWindow._lastQuickPick.items.find((i) => i.value === 'allow');
+        assert.ok(allowItem, 'allow item must exist');
+        assert.ok(allowItem.detail && allowItem.detail.length > 0, 'allow item must have a detail (tooltip equivalent)');
         assert.deepEqual(mockState.killDecision, { id: 'req-1', decision: 'allow', deferSeconds: undefined });
     });
 
-    test('writes defer decision when operator chooses hold fire', async () => {
+    test('writes defer decision when operator selects defer item', async () => {
         resetState({
             killRequest: {
                 id: 'req-2',
@@ -377,11 +387,57 @@ describe('update() — interactive kill approval prompt', () => {
                 reason: 'Stage 3 reclaim',
             },
         });
-        mockWindow._warnChoices.push('Hold fire (2 min)');
+        mockWindow._quickPickChoices.push('defer');
 
         const item = makeItem();
         await update(item);
 
+        const deferItem = mockWindow._lastQuickPick.items.find((i) => i.value === 'defer');
+        assert.ok(deferItem, 'defer item must exist');
+        assert.ok(deferItem.detail && deferItem.detail.length > 0, 'defer item must have a detail (tooltip equivalent)');
         assert.deepEqual(mockState.killDecision, { id: 'req-2', decision: 'defer', deferSeconds: 120 });
+    });
+
+    test('defaults to allow when dismissed (Escape / no choice)', async () => {
+        resetState({
+            killRequest: {
+                id: 'req-3',
+                ts: 125,
+                signal: 'TERM',
+                mode: 'normal',
+                reason: '',
+            },
+        });
+        // Nothing pushed to _quickPickChoices → simulates Escape/dismiss
+        const item = makeItem();
+        await update(item);
+
+        assert.ok(mockWindow._lastQuickPick, 'createQuickPick() should have been called even on dismiss');
+        assert.deepEqual(mockState.killDecision, { id: 'req-3', decision: 'allow', deferSeconds: undefined },
+            'dismiss must default to allow to preserve the safety posture');
+    });
+
+    test('shows explanation message and allows when help item is selected', async () => {
+        resetState({
+            killRequest: {
+                id: 'req-4',
+                ts: 126,
+                signal: 'TERM',
+                mode: 'normal',
+                reason: 'ACCEL rss_delta=412MB',
+            },
+        });
+        mockWindow._quickPickChoices.push('help');
+
+        const item = makeItem();
+        await update(item);
+
+        assert.ok(mockWindow._infoMessages.length >= 1,
+            'help choice must show an informationMessage explanation');
+        assert.ok(mockWindow._infoMessages[0].length > 40,
+            'explanation message should be substantive, not empty');
+        // After help, decision should default to allow so the daemon is unblocked
+        assert.deepEqual(mockState.killDecision, { id: 'req-4', decision: 'allow', deferSeconds: undefined },
+            'help choice must fall through to allow to unblock the daemon');
     });
 });


### PR DESCRIPTION
## Summary

Closes #160

Replaces the `showWarningMessage({ modal: true })` kill-approval prompt with `createQuickPick()` for a VS Code-native, theme-aware UX with functional tooltip-equivalent detail lines on each item.

## Changes

### `extension.js`
- **`humanizeReason(raw)`** — new helper that translates daemon reason tokens (e.g. `ACCEL rss_delta=412MB`) to plain English (e.g. `VS Code RSS is rising fast`)
- **`maybeHandleKillApprovalPrompt()`** — completely rewritten to use `createQuickPick()`:
  - Title: `Mem Watchdog — Intervention Approval`
  - Placeholder: live metrics (`% free  ·  MB avail  ·  RSS  ·  PSI  ·  trend sparkline`)
  - 3 items, each with `.detail` acting as a tooltip:
    - **Allow intervention** — SIGTERM target explained, emergency gates unaffected
    - **Hold fire — N min** — defer window explained, emergency override clarified
    - **What does this mean?** — opens `showInformationMessage` explanation, then allows
  - `_resolved` flag prevents double-resolution when `onDidHide` fires after `onDidAccept`
  - Dismiss/Escape → allow (safety posture preserved)

### Tests
- Replaced 2 `showWarningMessage`-based tests with 4 `createQuickPick` tests
- Added dismiss→allow and help→info+allow tests
- Added `createQuickPick` mock to `mockVscode.js` (`_quickPickChoices`, `_lastQuickPick`)

## Gate Evidence

| Gate | Result |
|---|---|
| `bash -n mem-watchdog.sh` | PASS |
| `shellcheck --shell=bash -e SC1091,SC2317` | PASS |
| `npm test` | 191/191 PASS (was 189, net +2) |
| `bash tests/test-watchdog.sh` | 20/20 PASS |
| `bash scripts/docs-integrity-check.sh` | 9/9 PASS |

## Type / Priority / Domain
- type: task
- priority: medium
- domain: extension