### PR TITLE
fix(extension): harden Marketplace signature release integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Daemon versions use `YYYYMMDD.N` (datestamp + revision).
 
 ## [Unreleased]
 
+## Extension v0.3.23 / Daemon v20260406.1 — 2026-04-09
+
+### Fixed
+- **Marketplace signature/update failure remediation** ([#168](https://github.com/chf3198/crostini-mem-watchdog/issues/168)) — republished extension to resolve `PackageIntegrityCheckFailed` during normal Marketplace update/install flow.
+
+### Changed
+- **Post-publish signature/package integrity gate** ([#168](https://github.com/chf3198/crostini-mem-watchdog/issues/168)) — `scripts/release-integrity-check.sh --post-publish` now verifies CDN VSIX SHA-256 and size against signed `.signature.manifest` from `Microsoft.VisualStudio.Services.VsixSignature`, preventing future signature/package drift from passing release closeout.
+
 ## Extension v0.3.22 / Daemon v20260406.1 — 2026-04-07
 
 ### Fixed

--- a/docs/workflow/learnings.md
+++ b/docs/workflow/learnings.md
@@ -20,6 +20,22 @@
 
 ---
 
+### 2026-04-09 — Marketplace signature incidents require signed-manifest vs CDN package parity checks
+
+**Context**: Investigating issue #168 where VS Code update to `v0.3.22` failed with `PackageIntegrityCheckFailed` despite the extension being published and discoverable in Marketplace.
+
+**Discovery**:
+1. A release can present as "published" while the Marketplace signature verification path still fails if the CDN VSIX bytes don't match the signed package digest in `.signature.manifest`.
+2. Version-only checks (`package.json`, `vsce show`, Marketplace page version) are insufficient — they do not prove signature-verifier parity.
+3. The authoritative check is: download `Microsoft.VisualStudio.Services.VSIXPackage` and `Microsoft.VisualStudio.Services.VsixSignature`, extract `.signature.manifest`, then compare package SHA-256 and size against signed `package` fields.
+4. The Marketplace `latest` endpoint is publisher-case-sensitive in practice for this path (`CurtisFranks` works; lowercase can return "extension doesn't exist" payloads), so release scripts should use canonical publisher casing.
+
+**Application**:
+- `scripts/release-integrity-check.sh --post-publish` now includes signed-manifest vs CDN package parity verification (SHA-256 + size), failing release closeout on mismatch.
+- Release governance for VS Code extensions should treat this parity gate as required evidence, not optional diagnostics.
+
+---
+
 ### 2026-04-07 — VS Code Shared Process has zero auto-restart; NodeService process differentiation requires child-process detection + `--inspect-port`
 
 **Context**: After v0.3.21 shipped, the user reported "A shared background process terminated unexpectedly. Please restart the application to recover." toasts and HTML Language Server crashing 5× (permanent death) during Playwright MCP sessions. Issue #80 (PR #81) added the PTY Host PID exclusion with a comment claiming Shared Process, File Watcher, and Network Service "are safe to kill — they auto-restart."

--- a/scripts/release-integrity-check.sh
+++ b/scripts/release-integrity-check.sh
@@ -86,6 +86,124 @@ if [[ $POST_PUBLISH -eq 1 ]]; then
     else
         FAIL "Marketplace version ($market_ver) != package.json ($pkg_version)"
     fi
+
+    # Signature/package consistency gate: validate the CDN VSIX byte hash against
+    # the signed .signature.manifest package digest. This catches
+    # PackageIntegrityCheckFailed incidents before closeout.
+    tmp_dir="$(mktemp -d)"
+    latest_json="$tmp_dir/latest.json"
+    sig_zip="$tmp_dir/sig.zip"
+    package_file="$tmp_dir/package.vsix"
+    sig_manifest="$tmp_dir/.signature.manifest"
+
+    if curl -fsSL \
+        -H 'Accept: application/json;api-version=7.2-preview' \
+        -H 'User-Agent: VSCode 1.108.0 (Code)' \
+        -H 'X-Market-Client-Id: VSCode 1.108.0' \
+        "https://marketplace.visualstudio.com/_apis/public/gallery/vscode/CurtisFranks/mem-watchdog-status/latest" \
+        >"$latest_json"; then
+        PASS "Fetched Marketplace latest metadata payload"
+    else
+        FAIL "Could not fetch Marketplace latest metadata payload"
+    fi
+
+    latest_version=""
+    package_url=""
+    signature_url=""
+    while IFS=$'\t' read -r _key _value; do
+        case "$_key" in
+            version) latest_version="$_value" ;;
+            package_url) package_url="$_value" ;;
+            signature_url) signature_url="$_value" ;;
+        esac
+    done < <(
+        python3 - "$latest_json" <<'PY'
+import json, sys
+p = sys.argv[1]
+with open(p, 'r', encoding='utf-8') as f:
+    obj = json.load(f)
+vers = (obj.get('versions') or [])
+if not vers:
+    sys.exit(0)
+v = vers[0]
+print('version\t' + str(v.get('version', '')))
+for file_obj in v.get('files', []):
+    t = str(file_obj.get('assetType', ''))
+    s = str(file_obj.get('source', ''))
+    if t == 'Microsoft.VisualStudio.Services.VSIXPackage':
+        print('package_url\t' + s)
+    elif t == 'Microsoft.VisualStudio.Services.VsixSignature':
+        print('signature_url\t' + s)
+PY
+    )
+
+    if [[ "$latest_version" == "$pkg_version" ]]; then
+        PASS "Latest metadata version matches package.json ($latest_version)"
+    else
+        FAIL "Latest metadata version ($latest_version) != package.json ($pkg_version)"
+    fi
+
+    if [[ -n "$package_url" && -n "$signature_url" ]]; then
+        PASS "Located VSIX package and signature URLs in metadata"
+    else
+        FAIL "Missing VSIX package/signature URLs in latest metadata"
+    fi
+
+    if curl -fsSL "$package_url" -o "$package_file"; then
+        PASS "Downloaded CDN VSIX package"
+    else
+        FAIL "Could not download CDN VSIX package"
+    fi
+
+    if curl -fsSL "$signature_url" -o "$sig_zip"; then
+        PASS "Downloaded VSIX signature archive"
+    else
+        FAIL "Could not download VSIX signature archive"
+    fi
+
+    if unzip -p "$sig_zip" .signature.manifest >"$sig_manifest" 2>/dev/null; then
+        PASS "Extracted .signature.manifest"
+    else
+        FAIL "Could not extract .signature.manifest"
+    fi
+
+    pkg_hash_actual=""
+    pkg_size_actual=""
+    read -r pkg_hash_actual pkg_size_actual < <(
+        python3 - "$package_file" <<'PY'
+import base64, hashlib, os, sys
+path = sys.argv[1]
+with open(path, 'rb') as f:
+    b = f.read()
+print(base64.b64encode(hashlib.sha256(b).digest()).decode(), os.path.getsize(path))
+PY
+    )
+
+    pkg_hash_expected=""
+    pkg_size_expected=""
+    read -r pkg_hash_expected pkg_size_expected < <(
+        python3 - "$sig_manifest" <<'PY'
+import json, sys
+with open(sys.argv[1], 'r', encoding='utf-8') as f:
+    obj = json.load(f)
+pkg = obj.get('package', {})
+print(pkg.get('digests', {}).get('sha256', ''), pkg.get('size', ''))
+PY
+    )
+
+    if [[ -n "$pkg_hash_expected" && "$pkg_hash_actual" == "$pkg_hash_expected" ]]; then
+        PASS "CDN VSIX hash matches signed manifest"
+    else
+        FAIL "CDN VSIX hash mismatch vs signed manifest (actual=$pkg_hash_actual expected=$pkg_hash_expected)"
+    fi
+
+    if [[ -n "$pkg_size_expected" && "$pkg_size_actual" == "$pkg_size_expected" ]]; then
+        PASS "CDN VSIX size matches signed manifest ($pkg_size_actual bytes)"
+    else
+        FAIL "CDN VSIX size mismatch vs signed manifest (actual=$pkg_size_actual expected=$pkg_size_expected)"
+    fi
+
+    rm -rf "$tmp_dir"
 fi
 
 echo ""

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [0.3.23] — 2026-04-09
+
+### Fixed
+- **Marketplace update signature failure remediation** ([#168](https://github.com/chf3198/crostini-mem-watchdog/issues/168)) — republished extension to clear the `PackageIntegrityCheckFailed` update/install path seen on `v0.3.22` and restore normal Marketplace update flow.
+
+### Changed
+- **Release integrity guard strengthened** ([#168](https://github.com/chf3198/crostini-mem-watchdog/issues/168)) — `scripts/release-integrity-check.sh --post-publish` now downloads the CDN VSIX package + signature archive, parses `.signature.manifest`, and verifies package SHA-256/size match signed metadata. This catches package/signature drift before release closeout.
+
 ## [0.3.22] — 2026-04-07
 
 ### Fixed

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "mem-watchdog-status",
   "displayName": "Mem Watchdog",
   "description": "Prevents VS Code from being OOM-killed on ChromeOS Crostini — auto-installs a systemd memory watchdog daemon that kills Chrome/Playwright before the kernel kills VS Code.",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "publisher": "CurtisFranks",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {


### PR DESCRIPTION
## Summary
- harden `scripts/release-integrity-check.sh --post-publish` with signed-manifest parity validation against CDN VSIX bytes
- bump extension version to `0.3.23`
- document the incident and guardrail in root + extension changelogs and learnings log

## Root cause
Issue #168 showed Marketplace could present a version as published while update/install still fails with `PackageIntegrityCheckFailed` if CDN package bytes do not match signed `.signature.manifest` metadata.

## Changes
- add Marketplace `latest` metadata fetch using canonical publisher casing (`CurtisFranks`)
- parse package/signature asset URLs
- download VSIX + signature archive
- extract `.signature.manifest`
- compare CDN VSIX SHA-256 (base64) and size to signed `package` fields
- fail release integrity closeout on mismatch

## Validation
- `bash tests/test-watchdog.sh` → 20 passed, 0 failed
- `bash -n mem-watchdog.sh` → pass
- `shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh scripts/watchdog-tray.sh install.sh` → pass
- `cd vscode-extension && npm test` → 191 passed, 0 failed
- `bash scripts/docs-integrity-check.sh` → 9 passed, 0 failed
- `bash scripts/release-integrity-check.sh` → 3 passed, 0 failed

Closes #168
