### PR TITLE
fix(release): target exact version for post-publish parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Daemon versions use `YYYYMMDD.N` (datestamp + revision).
 
 ## [Unreleased]
 
+### Changed
+- **Release-integrity target-version parity source hardened** ([#171](https://github.com/chf3198/crostini-mem-watchdog/issues/171)) — `scripts/release-integrity-check.sh --post-publish` now validates VSIX/signature parity using Marketplace ExtensionQuery for the exact `package.json` version. The `/latest` endpoint is treated as informational because it can lag after publish.
+
 ## Extension v0.3.23 / Daemon v20260406.1 — 2026-04-09
 
 ### Fixed

--- a/docs/workflow/learnings.md
+++ b/docs/workflow/learnings.md
@@ -36,6 +36,21 @@
 
 ---
 
+### 2026-04-09 — Marketplace `/latest` can lag after publish; parity checks must target the exact version
+
+**Context**: After publishing `v0.3.23`, release-integrity checks still failed because Marketplace `/latest` returned `0.3.22` while `vsce show` and ExtensionQuery already exposed `0.3.23`.
+
+**Discovery**:
+1. Marketplace surfaces are eventually consistent and can diverge temporarily: listing/version APIs can show the new version before `/latest` updates.
+2. A hard gate tied to `/latest` creates false negatives and can block release closeout even when the target version is healthy.
+3. ExtensionQuery (`_apis/public/gallery/extensionquery`) returns version-specific assets for the published target and is suitable for deterministic parity checks.
+
+**Application**:
+- `scripts/release-integrity-check.sh --post-publish` now uses ExtensionQuery to locate the exact `package.json` version and validates VSIX/signature parity against that version’s assets.
+- `/latest` is retained as informational telemetry only (lag warning), not a release-blocking condition.
+
+---
+
 ### 2026-04-07 — VS Code Shared Process has zero auto-restart; NodeService process differentiation requires child-process detection + `--inspect-port`
 
 **Context**: After v0.3.21 shipped, the user reported "A shared background process terminated unexpectedly. Please restart the application to recover." toasts and HTML Language Server crashing 5× (permanent death) during Playwright MCP sessions. Issue #80 (PR #81) added the PTY Host PID exclusion with a comment claiming Shared Process, File Watcher, and Network Service "are safe to kill — they auto-restart."

--- a/scripts/release-integrity-check.sh
+++ b/scripts/release-integrity-check.sh
@@ -19,6 +19,7 @@ fail=0
 
 PASS() { ((++pass)); echo "  ✓ $1"; }
 FAIL() { ((++fail)); echo "  ✗ $1"; }
+INFO() { echo "  • $1"; }
 
 pkg_version="$(node -e "process.stdout.write(require('./vscode-extension/package.json').version)")"
 root_daemon_version="$(grep -m1 -oP '^(?:export\s+)?WATCHDOG_VERSION=\K[0-9]+(?:\.[0-9]+)?' mem-watchdog.sh || true)"
@@ -88,10 +89,11 @@ if [[ $POST_PUBLISH -eq 1 ]]; then
     fi
 
     # Signature/package consistency gate: validate the CDN VSIX byte hash against
-    # the signed .signature.manifest package digest. This catches
-    # PackageIntegrityCheckFailed incidents before closeout.
+    # the signed .signature.manifest package digest for the exact published version.
+    # `/latest` can lag after publish, so it is informational only.
     tmp_dir="$(mktemp -d)"
     latest_json="$tmp_dir/latest.json"
+    query_json="$tmp_dir/extensionquery.json"
     sig_zip="$tmp_dir/sig.zip"
     package_file="$tmp_dir/package.vsix"
     sig_manifest="$tmp_dir/.signature.manifest"
@@ -102,51 +104,78 @@ if [[ $POST_PUBLISH -eq 1 ]]; then
         -H 'X-Market-Client-Id: VSCode 1.108.0' \
         "https://marketplace.visualstudio.com/_apis/public/gallery/vscode/CurtisFranks/mem-watchdog-status/latest" \
         >"$latest_json"; then
-        PASS "Fetched Marketplace latest metadata payload"
+        latest_version="$(python3 - "$latest_json" <<'PY'
+import json, sys
+with open(sys.argv[1], 'r', encoding='utf-8') as f:
+    obj = json.load(f)
+vers = (obj.get('versions') or [])
+print(str(vers[0].get('version', '')) if vers else '')
+PY
+)"
+        if [[ "$latest_version" == "$pkg_version" ]]; then
+            PASS "Latest metadata version matches package.json ($latest_version)"
+        else
+            INFO "Latest metadata version is $latest_version while target is $pkg_version (allowed lag)"
+        fi
     else
-        FAIL "Could not fetch Marketplace latest metadata payload"
+        INFO "Could not fetch Marketplace latest metadata payload (continuing with target-version query)"
     fi
 
-    latest_version=""
+    if curl -fsSL \
+        -H 'Content-Type: application/json' \
+        -H 'Accept: application/json;api-version=7.2-preview.1' \
+        --data '{"filters":[{"criteria":[{"filterType":7,"value":"CurtisFranks.mem-watchdog-status"}]}],"flags":8067}' \
+        "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery" \
+        >"$query_json"; then
+        PASS "Fetched Marketplace extensionquery metadata"
+    else
+        FAIL "Could not fetch Marketplace extensionquery metadata"
+    fi
+
+    target_version=""
     package_url=""
     signature_url=""
     while IFS=$'\t' read -r _key _value; do
         case "$_key" in
-            version) latest_version="$_value" ;;
+            target_version) target_version="$_value" ;;
             package_url) package_url="$_value" ;;
             signature_url) signature_url="$_value" ;;
         esac
     done < <(
-        python3 - "$latest_json" <<'PY'
+        python3 - "$query_json" "$pkg_version" <<'PY'
 import json, sys
-p = sys.argv[1]
-with open(p, 'r', encoding='utf-8') as f:
+with open(sys.argv[1], 'r', encoding='utf-8') as f:
     obj = json.load(f)
-vers = (obj.get('versions') or [])
-if not vers:
+target = sys.argv[2]
+results = obj.get('results') or []
+extensions = (results[0].get('extensions') if results else []) or []
+if not extensions:
     sys.exit(0)
-v = vers[0]
-print('version\t' + str(v.get('version', '')))
-for file_obj in v.get('files', []):
-    t = str(file_obj.get('assetType', ''))
-    s = str(file_obj.get('source', ''))
-    if t == 'Microsoft.VisualStudio.Services.VSIXPackage':
-        print('package_url\t' + s)
-    elif t == 'Microsoft.VisualStudio.Services.VsixSignature':
-        print('signature_url\t' + s)
+versions = extensions[0].get('versions') or []
+for v in versions:
+    if str(v.get('version', '')) == target:
+        print('target_version\t' + str(v.get('version', '')))
+        for file_obj in v.get('files', []):
+            t = str(file_obj.get('assetType', ''))
+            s = str(file_obj.get('source', ''))
+            if t == 'Microsoft.VisualStudio.Services.VSIXPackage':
+                print('package_url\t' + s)
+            elif t == 'Microsoft.VisualStudio.Services.VsixSignature':
+                print('signature_url\t' + s)
+        break
 PY
     )
 
-    if [[ "$latest_version" == "$pkg_version" ]]; then
-        PASS "Latest metadata version matches package.json ($latest_version)"
+    if [[ "$target_version" == "$pkg_version" ]]; then
+        PASS "Target version metadata found in extensionquery ($target_version)"
     else
-        FAIL "Latest metadata version ($latest_version) != package.json ($pkg_version)"
+        FAIL "Target version $pkg_version not found in extensionquery"
     fi
 
     if [[ -n "$package_url" && -n "$signature_url" ]]; then
-        PASS "Located VSIX package and signature URLs in metadata"
+        PASS "Located VSIX package and signature URLs for target version"
     else
-        FAIL "Missing VSIX package/signature URLs in latest metadata"
+        FAIL "Missing VSIX package/signature URLs for target version"
     fi
 
     if curl -fsSL "$package_url" -o "$package_file"; then


### PR DESCRIPTION
## Summary
- switch post-publish parity validation to Marketplace ExtensionQuery for the exact package.json version
- keep /latest endpoint as informational lag telemetry only
- document the lag behavior in changelog and learnings

## Why
Marketplace /latest can lag after publish and caused false release-integrity failures even when target version assets were healthy.

## Validation
- bash tests/test-watchdog.sh -> 20 passed
- bash -n mem-watchdog.sh -> pass
- shellcheck --shell=bash -e SC1091,SC2317 mem-watchdog.sh scripts/watchdog-tray.sh install.sh -> pass
- cd vscode-extension && npm test -> 191 passed
- bash scripts/docs-integrity-check.sh -> 9 passed
- bash scripts/release-integrity-check.sh --post-publish -> 14 passed, 0 failed

Closes #171
